### PR TITLE
Switch to non-clipped versions of datasets

### DIFF
--- a/pipelines/dist_flow.py
+++ b/pipelines/dist_flow.py
@@ -15,8 +15,6 @@ from pipelines.disturbance.gadm_dist_alerts_by_natural_lands import (
 )
 from pipelines.disturbance.gadm_dist_alerts_by_driver import gadm_dist_alerts_by_driver
 
-DATA_LAKE_BUCKET = "gfw-data-lake"
-
 logging.getLogger("distributed.client").setLevel(logging.ERROR)
 
 
@@ -80,6 +78,7 @@ def main(overwrite=False) -> list[str]:
     result_uris = []
     try:
         dist_version = get_new_dist_version()
+        logger.info(f"Latest dist version: {dist_version}")
         dask_client, _ = create_cluster()
         dist_zarr_uri = create_zarr(dist_version, overwrite=overwrite)
         gadm_dist_result = analyze_gadm_dist(dist_zarr_uri, dist_version, overwrite=overwrite)

--- a/pipelines/disturbance/create_zarr.py
+++ b/pipelines/disturbance/create_zarr.py
@@ -2,9 +2,7 @@ import numpy as np
 import xarray as xr
 
 from .check_for_new_alerts import s3_object_exists
-
-
-data_lake_bucket = "gfw-data-lake"
+from ..globals import DATA_LAKE_BUCKET
 
 
 def decode_alert_data(band_data) -> xr.Dataset:
@@ -20,10 +18,10 @@ def create_zarr(version, overwrite=False) -> str:
     """create a full extent zarr file in s3."""
     base_folder = f"umd_glad_dist_alerts/{version}/raster/epsg-4326"
     key = f"{base_folder}/zarr/umd_glad_dist_alerts.zarr"
-    zarr_uri = f"s3://{data_lake_bucket}/{key}"
-    cog_uri = f"s3://{data_lake_bucket}/{base_folder}/cog/default.tif"
+    zarr_uri = f"s3://{DATA_LAKE_BUCKET}/{key}"
+    cog_uri = f"s3://{DATA_LAKE_BUCKET}/{base_folder}/cog/default.tif"
 
-    if s3_object_exists(data_lake_bucket, f"{key}/zarr.json") and not overwrite:
+    if s3_object_exists(DATA_LAKE_BUCKET, f"{key}/zarr.json") and not overwrite:
         return zarr_uri
 
     dataset = xr.open_dataset(cog_uri, chunks="auto").band_data.chunk(

--- a/pipelines/disturbance/gadm_dist_alerts_by_driver.py
+++ b/pipelines/disturbance/gadm_dist_alerts_by_driver.py
@@ -6,8 +6,7 @@ from flox.xarray import xarray_reduce
 from flox import ReindexArrayType, ReindexStrategy
 
 from .check_for_new_alerts import s3_object_exists
-
-DATA_LAKE_BUCKET = "gfw-data-lake"
+from ..globals import DATA_LAKE_BUCKET, country_zarr_uri, region_zarr_uri, subregion_zarr_uri
 
 def gadm_dist_alerts_by_driver(zarr_uri: str, version: str, overwrite: bool) -> str:
     """Run DIST alerts analysis by driver using Dask to create parquet, upload to S3 and return URI."""
@@ -21,17 +20,16 @@ def gadm_dist_alerts_by_driver(zarr_uri: str, version: str, overwrite: bool) -> 
 
     dist_alerts = xr.open_zarr(zarr_uri)
 
-    countries_from_clipped = xr.open_zarr(
-        "s3://gfw-data-lake/gadm_administrative_boundaries/v4.1.85/raster/epsg-4326/zarr/adm0_clipped_to_dist.zarr"
-    ).band_data
-    regions_from_clipped = xr.open_zarr(
-        "s3://gfw-data-lake/gadm_administrative_boundaries/v4.1.85/raster/epsg-4326/zarr/adm1_clipped_to_dist.zarr"
-    ).band_data
-    subregions_from_clipped = xr.open_zarr(
-        "s3://gfw-data-lake/gadm_administrative_boundaries/v4.1.85/raster/epsg-4326/zarr/adm2_clipped_to_dist.zarr"
-    ).band_data
+    country = xr.open_zarr(country_zarr_uri)
+    country_from_clipped = xr.align(dist_alerts, country, join='left')[1].band_data
+    region = xr.open_zarr(region_zarr_uri)
+    region_from_clipped = xr.align(dist_alerts, region, join='left')[1].band_data
+    subregion = xr.open_zarr(subregion_zarr_uri)
+    subregion_from_clipped = xr.align(dist_alerts, subregion, join='left')[1].band_data
+
+    # This is actually an already-clipped versions of drivers
     dist_drivers_from_clipped = xr.open_zarr(
-        "s3://gfw-data-lake/umd_glad_dist_alerts_driver/zarr/umd_dist_alerts_drivers.zarr"
+        f"s3://{DATA_LAKE_BUCKET}/umd_glad_dist_alerts_driver/zarr/umd_dist_alerts_drivers.zarr"
     ).band_data
 
     adm0_ids = [
@@ -56,17 +54,17 @@ def gadm_dist_alerts_by_driver(zarr_uri: str, version: str, overwrite: bool) -> 
 
     alert_dates = np.arange(731, 1590)
 
-    countries_from_clipped.name = "countries"
-    regions_from_clipped.name = "regions"
-    subregions_from_clipped.name = "subregions"
+    country_from_clipped.name = "countries"
+    region_from_clipped.name = "regions"
+    subregion_from_clipped.name = "subregions"
     dist_drivers_from_clipped.name = "driver"
     print("Starting reduce")
     alerts_count = xarray_reduce(
         dist_alerts.confidence,
         *(
-            countries_from_clipped,
-            regions_from_clipped,
-            subregions_from_clipped,
+            country_from_clipped,
+            region_from_clipped,
+            subregion_from_clipped,
             dist_drivers_from_clipped,
             dist_alerts.alert_date,
             dist_alerts.confidence

--- a/pipelines/globals.py
+++ b/pipelines/globals.py
@@ -1,0 +1,6 @@
+DATA_LAKE_BUCKET = "gfw-data-lake"
+GADM_VERSION = "v4.1.85"
+
+country_zarr_uri = f"s3://{DATA_LAKE_BUCKET}/gadm_administrative_boundaries/{GADM_VERSION}/raster/epsg-4326/zarr/adm0.zarr"
+region_zarr_uri = f"s3://{DATA_LAKE_BUCKET}/gadm_administrative_boundaries/{GADM_VERSION}/raster/epsg-4326/zarr/adm1.zarr"
+subregion_zarr_uri = f"s3://{DATA_LAKE_BUCKET}/gadm_administrative_boundaries/{GADM_VERSION}/raster/epsg-4326/zarr/adm2.zarr"


### PR DESCRIPTION
Switch to non-clipped versions of datasets
 - Use the non-clipped versions of datasets and do xr.align on the fly.
 - Moved a bunch of duplicated constants to pipelines/globals.py.
 - Made some names consistent (singular rather than plural)

Still need to create a non-clipped zarr of natural lands.
