### PR TITLE
PZB-250 Refactor natural lands, include drivers refactor from Daniel, then extract common code to stages.py

### DIFF
--- a/pipelines/dist_flow.py
+++ b/pipelines/dist_flow.py
@@ -63,7 +63,7 @@ def analyze_gadm_dist_by_natural_lands(dist_zarr_uri, version, overwrite: bool):
 @task
 def analyze_gadm_dist_by_driver(dist_zarr_uri, version, overwrite: bool):
 
-    return gadm_dist_alerts_by_driver(dist_zarr_uri, version, overwrite)
+    return gadm_dist_alerts_by_driver(dist_zarr_uri, version, overwrite=overwrite)
 
 
 @task

--- a/pipelines/dist_flow.py
+++ b/pipelines/dist_flow.py
@@ -57,7 +57,7 @@ def analyze_gadm_dist(dist_zarr_uri, version, overwrite: bool):
 @task
 def analyze_gadm_dist_by_natural_lands(dist_zarr_uri, version, overwrite: bool):
 
-    return gadm_dist_alerts_by_natural_lands(dist_zarr_uri, version, overwrite)
+    return gadm_dist_alerts_by_natural_lands(dist_zarr_uri, version, overwrite=overwrite)
 
 
 @task

--- a/pipelines/disturbance/gadm_dist_alerts.py
+++ b/pipelines/disturbance/gadm_dist_alerts.py
@@ -25,11 +25,11 @@ def gadm_dist_alerts(
 
     expected_groups = (
         (
-            np.arange(894),  # country value range
-            np.arange(86),   # region value range
-            np.arange(854),  # subregion value range
-            np.arange(731, 1590),  # dates value range
-            [1, 2, 3],       # confidence value range
+            np.arange(894),  # country ISO codes
+            np.arange(86),   # region codes
+            np.arange(854),  # subregion codes
+            np.arange(731, 1590),  # dates values
+            [1, 2, 3],       # confidence values
         )
         if groups is None
         else groups

--- a/pipelines/disturbance/gadm_dist_alerts.py
+++ b/pipelines/disturbance/gadm_dist_alerts.py
@@ -10,33 +10,7 @@ from flox.xarray import xarray_reduce
 from .check_for_new_alerts import s3_object_exists
 from ..globals import DATA_LAKE_BUCKET, country_zarr_uri, region_zarr_uri, subregion_zarr_uri
 
-LoaderType = Callable[[str], Tuple[xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset]]
-ExpectedGroupsType = Tuple
-SaverType = Callable[[pd.DataFrame, str], None]
-
-
-def _s3_loader(
-    dist_zarr_uri: str,
-) -> Tuple[xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset]:
-
-    dist_alerts = xr.open_zarr(dist_zarr_uri)
-
-    country = xr.open_zarr(country_zarr_uri)
-    country_from_clipped = xr.align(dist_alerts, country, join='left')[1]
-    region = xr.open_zarr(region_zarr_uri)
-    region_from_clipped = xr.align(dist_alerts, region, join='left')[1]
-    subregion = xr.open_zarr(subregion_zarr_uri)
-    subregion_from_clipped = xr.align(dist_alerts, subregion, join='left')[1]
-    return (
-        dist_alerts,
-        country_from_clipped,
-        region_from_clipped,
-        subregion_from_clipped
-    )
-
-
-def _parquet_saver(alerts_count_df: pd.DataFrame, results_uri: str) -> None:
-    alerts_count_df.to_parquet(results_uri, index=False)
+from .gadm_dist_alerts_by_natural_lands import LoaderType, ExpectedGroupsType, SaverType, _s3_loader, _parquet_saver, _setup, _compute, _create_data_frame, _save_results, pipe
 
 
 def gadm_dist_alerts(
@@ -50,6 +24,22 @@ def gadm_dist_alerts(
     """Count DIST alerts by GADM boundary, confidence, and date, and export grouped results to a Parquet file in S3."""
     logging.getLogger("distributed.client").setLevel(logging.ERROR)
 
+    # No contextual layer
+    contextual_uri = None
+    contextual_column_name = None
+
+    expected_groups = (
+        (
+            np.arange(894),  # country value range
+            np.arange(86),   # region value range
+            np.arange(854),  # subregion value range
+            np.arange(731, 1590),  # dates value range
+            [1, 2, 3],       # confidence value range
+        )
+        if groups is None
+        else groups
+    )
+
     results_key = f"umd_glad_dist_alerts/{dist_version}/tabular/epsg-4326/zonal_stats/dist_alerts_by_adm2.parquet"
     results_uri = f"s3://{DATA_LAKE_BUCKET}/{results_key}"
 
@@ -57,80 +47,9 @@ def gadm_dist_alerts(
         return results_uri
 
     return pipe(
-        loader(dist_zarr_uri),
-        lambda d: _setup(*d, groups),
+        loader(dist_zarr_uri, contextual_uri),
+        lambda d: _setup(d, expected_groups, contextual_column_name),
         lambda s: _compute(*s),
         _create_data_frame,
         lambda df: _save_results(df, dist_version, saver, results_uri),
     )
-
-
-def _setup(
-    dist_alerts: xr.Dataset,
-    country: xr.Dataset,
-    region: xr.Dataset,
-    subregion: xr.Dataset,
-    expected_groups: Tuple,
-) -> Tuple:
-    groups = (
-        (
-            np.arange(894),
-            np.arange(86),
-            np.arange(854),
-            np.arange(731, 1590),
-            [1, 2, 3],
-        )
-        if expected_groups is None
-        else expected_groups
-    )
-
-    return (
-        dist_alerts.confidence,
-        (
-            country.band_data.rename("country"),
-            region.band_data.rename("region"),
-            subregion.band_data.rename("subregion"),
-            dist_alerts.alert_date,
-            dist_alerts.confidence,
-        ),
-        groups,
-    )
-
-
-def _compute(reduce_mask: xr.DataArray, reduce_groupbys: Tuple, expected_groups: Tuple):
-    return xarray_reduce(
-        reduce_mask,
-        *reduce_groupbys,
-        func="count",
-        expected_groups=expected_groups,
-        reindex=ReindexStrategy(
-            blockwise=False, array_type=ReindexArrayType.SPARSE_COO
-        ),
-        fill_value=0,
-    ).compute()
-
-
-def _create_data_frame(alerts_count: xr.Dataset) -> pd.DataFrame:
-    sparse_data = alerts_count.data
-    dim_names = alerts_count.dims
-    indices = sparse_data.coords
-    values = sparse_data.data
-
-    coord_dict = {
-        dim: alerts_count.coords[dim].values[idx]
-        for dim, idx in zip(dim_names, indices)
-    }
-    coord_dict["value"] = values
-
-    return pd.DataFrame(coord_dict)
-
-
-def _save_results(
-    alerts_count_df: pd.DataFrame, dist_version: str, saver: Callable, results_uri: str
-) -> str:
-    saver(alerts_count_df, results_uri)
-    return results_uri
-
-
-def pipe(value, *functions):
-    return reduce(lambda v, f: f(v), functions, value)

--- a/pipelines/disturbance/gadm_dist_alerts.py
+++ b/pipelines/disturbance/gadm_dist_alerts.py
@@ -1,16 +1,11 @@
 import logging
-from functools import reduce
-from typing import Callable, Tuple, Optional
+from typing import Optional
 import numpy as np
-import pandas as pd
-import xarray as xr
-from flox import ReindexArrayType, ReindexStrategy
-from flox.xarray import xarray_reduce
 
 from .check_for_new_alerts import s3_object_exists
-from ..globals import DATA_LAKE_BUCKET, country_zarr_uri, region_zarr_uri, subregion_zarr_uri
+from ..globals import DATA_LAKE_BUCKET
 
-from .gadm_dist_alerts_by_natural_lands import LoaderType, ExpectedGroupsType, SaverType, _s3_loader, _parquet_saver, _setup, _compute, _create_data_frame, _save_results, pipe
+from .stages import LoaderType, ExpectedGroupsType, SaverType, _s3_loader, _parquet_saver, _setup, _compute, _create_data_frame, _save_results, pipe
 
 
 def gadm_dist_alerts(

--- a/pipelines/disturbance/gadm_dist_alerts_by_driver.py
+++ b/pipelines/disturbance/gadm_dist_alerts_by_driver.py
@@ -1,72 +1,11 @@
-from functools import reduce
-from typing import Callable, Optional, Tuple
-
 import logging
+from typing import Optional
 import numpy as np
-import pandas as pd
-import xarray as xr
-from flox import ReindexArrayType, ReindexStrategy
-from flox.xarray import xarray_reduce
 
 from .check_for_new_alerts import s3_object_exists
-from ..globals import DATA_LAKE_BUCKET, country_zarr_uri, region_zarr_uri, subregion_zarr_uri
+from ..globals import DATA_LAKE_BUCKET
 
-
-LoaderType = Callable[[str], Tuple[xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset]]
-ExpectedGroupsType = Tuple
-SaverType = Callable[[pd.DataFrame, str], None]
-
-adm0_ids = [
-    0, 4, 8, 10, 12, 16, 20, 24, 28, 31, 32, 36, 40, 44, 48, 50, 51, 52, 56, 60,
-    64, 68, 70, 72, 74, 76, 84, 86, 90, 92, 96, 100, 104, 108, 112, 116, 120,
-    124, 132, 136, 140, 144, 148, 152, 156, 158, 162, 166, 170, 174, 175, 178,
-    180, 184, 188, 191, 192, 196, 203, 204, 208, 212, 214, 218, 222, 226, 231,
-    232, 233, 234, 238, 239, 242, 246, 248, 250, 254, 258, 260, 262, 266, 268,
-    270, 275, 276, 288, 292, 296, 300, 304, 308, 312, 316, 320, 324, 328, 332,
-    334, 336, 340, 344, 348, 352, 356, 360, 364, 368, 372, 376, 380, 384, 388,
-    392, 398, 400, 404, 408, 410, 414, 417, 418, 422, 426, 428, 430, 434, 438,
-    440, 442, 446, 450, 454, 458, 462, 466, 470, 474, 478, 480, 484, 492, 496,
-    498, 499, 500, 504, 508, 512, 516, 520, 524, 528, 531, 533, 534, 535, 540,
-    548, 554, 558, 562, 566, 570, 574, 578, 580, 581, 583, 584, 585, 586, 591,
-    598, 600, 604, 608, 612, 616, 620, 624, 626, 630, 634, 638, 642, 643, 646,
-    652, 654, 659, 660, 662, 663, 666, 670, 674, 678, 682, 686, 688, 690, 694,
-    702, 703, 704, 705, 706, 710, 716, 724, 728, 729, 732, 740, 744, 748, 752,
-    756, 760, 762, 764, 768, 772, 776, 780, 784, 788, 792, 795, 796, 798, 800,
-    804, 807, 818, 826, 831, 832, 833, 834, 840, 850, 854, 858, 860, 862, 876,
-    882, 887, 894
-]
-
-
-def _s3_loader(
-    dist_zarr_uri: str,
-) -> Tuple[xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset]:
-
-    dist_alerts = xr.open_zarr(dist_zarr_uri)
-
-    country = xr.open_zarr(country_zarr_uri)
-    country_aligned = xr.align(dist_alerts, country, join='left')[1]
-    region = xr.open_zarr(region_zarr_uri)
-    region_aligned = xr.align(dist_alerts, region, join='left')[1]
-    subregion = xr.open_zarr(subregion_zarr_uri)
-    subregion_aligned = xr.align(dist_alerts, subregion, join='left')[1]
-
-    dist_drivers = xr.open_zarr(
-        f"s3://{DATA_LAKE_BUCKET}/umd_glad_dist_alerts_driver/zarr/umd_dist_alerts_drivers.zarr"
-    )
-    dist_drivers_aligned = xr.align(dist_alerts, dist_drivers, join='left')[1]
-
-    return (
-        dist_alerts,
-        country_aligned,
-        region_aligned,
-        subregion_aligned,
-        dist_drivers_aligned,
-    )
-
-
-def _parquet_saver(alerts_count_df: pd.DataFrame, results_uri: str) -> None:
-    alerts_count_df.to_parquet(results_uri, index=False)
-
+from .stages import LoaderType, ExpectedGroupsType, SaverType, _s3_loader, _parquet_saver, _setup, _compute, _create_data_frame, _save_results, pipe
 
 def gadm_dist_alerts_by_driver(
     dist_zarr_uri: str,
@@ -77,92 +16,33 @@ def gadm_dist_alerts_by_driver(
     overwrite: bool = False
 ) -> str:
     """Run DIST alerts analysis by driver using Dask to create parquet, upload to S3 and return URI."""
+    logging.getLogger("distributed.client").setLevel(logging.ERROR)
+
+    contextual_uri = f"s3://{DATA_LAKE_BUCKET}/umd_glad_dist_alerts_driver/zarr/umd_dist_alerts_drivers.zarr"
+
+    expected_groups = (
+        (
+            np.arange(894),        # country ISO codes
+            np.arange(86),         # region codes
+            np.arange(854),        # subregion codes
+            np.arange(5),          # driver categories
+            np.arange(731, 1590),  # dates values
+            [1, 2, 3],             # confidence values
+        ) if groups is None
+        else groups
+    )
+    contextual_column_name = 'driver'
+
     results_key = f"umd_glad_dist_alerts/{dist_version}/tabular/epsg-4326/zonal_stats/dist_alerts_by_adm2_driver.parquet"
     results_uri = f"s3://{DATA_LAKE_BUCKET}/{results_key}"
 
     if not overwrite and s3_object_exists(DATA_LAKE_BUCKET, results_key):
         return results_uri
 
-    logging.getLogger("distributed.client").setLevel(logging.ERROR)
-
     return pipe(
-        loader(dist_zarr_uri),
-        lambda d: _setup(*d, groups),
+        loader(dist_zarr_uri, contextual_uri),
+        lambda d: _setup(d, expected_groups, contextual_column_name),
         lambda s: _compute(*s),
         _create_data_frame,
         lambda df: _save_results(df, dist_version, saver, results_uri),
     )
-
-
-def _setup(
-    dist_alerts: xr.Dataset,
-    country: xr.Dataset,
-    region: xr.Dataset,
-    subregion: xr.Dataset,
-    dist_drivers: xr.Dataset,
-    expected_groups: Tuple,
-) -> Tuple:
-    groups = (
-        (
-            np.arange(894),        # country ISO codes
-            np.arange(86),         # region codes
-            np.arange(854),        # subregion codes
-            np.arange(5),          # driver categories
-            np.arange(731, 1590),  # days
-            [1, 2, 3],             # confidence values
-        )
-        if expected_groups is None
-        else expected_groups
-    )
-
-    return (
-        dist_alerts.confidence,
-        (
-            country.band_data.rename("country"),
-            region.band_data.rename("region"),
-            subregion.band_data.rename("subregion"),
-            dist_drivers.band_data.rename("driver"),
-            dist_alerts.alert_date,
-            dist_alerts.confidence,
-        ),
-        groups,
-    )
-
-
-def _compute(reduce_mask: xr.DataArray, reduce_groupbys: Tuple, expected_groups: Tuple):
-    return xarray_reduce(
-        reduce_mask,
-        *reduce_groupbys,
-        func="count",
-        expected_groups=expected_groups,
-        reindex=ReindexStrategy(
-            blockwise=False, array_type=ReindexArrayType.SPARSE_COO
-        ),
-        fill_value=0,
-    ).compute()
-
-
-def _create_data_frame(alerts_count: xr.Dataset) -> pd.DataFrame:
-    sparse_data = alerts_count.data
-    dim_names = alerts_count.dims
-    indices = sparse_data.coords
-    values = sparse_data.data
-
-    coord_dict = {
-        dim: alerts_count.coords[dim].values[idx]
-        for dim, idx in zip(dim_names, indices)
-    }
-    coord_dict["value"] = values
-
-    return pd.DataFrame(coord_dict)
-
-
-def _save_results(
-    alerts_count_df: pd.DataFrame, dist_version: str, saver: Callable, results_uri: str
-) -> str:
-    saver(alerts_count_df, results_uri)
-    return results_uri
-
-
-def pipe(value, *functions):
-    return reduce(lambda v, f: f(v), functions, value)

--- a/pipelines/disturbance/gadm_dist_alerts_by_driver.py
+++ b/pipelines/disturbance/gadm_dist_alerts_by_driver.py
@@ -1,16 +1,83 @@
-import numpy as np
-import xarray as xr
-import pandas as pd
+from functools import reduce
+from typing import Callable, Optional, Tuple
+
 import logging
-from flox.xarray import xarray_reduce
+import numpy as np
+import pandas as pd
+import xarray as xr
 from flox import ReindexArrayType, ReindexStrategy
+from flox.xarray import xarray_reduce
 
 from .check_for_new_alerts import s3_object_exists
 from ..globals import DATA_LAKE_BUCKET, country_zarr_uri, region_zarr_uri, subregion_zarr_uri
 
-def gadm_dist_alerts_by_driver(zarr_uri: str, version: str, overwrite: bool) -> str:
+
+LoaderType = Callable[[str], Tuple[xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset]]
+ExpectedGroupsType = Tuple
+SaverType = Callable[[pd.DataFrame, str], None]
+
+adm0_ids = [
+    0, 4, 8, 10, 12, 16, 20, 24, 28, 31, 32, 36, 40, 44, 48, 50, 51, 52, 56, 60,
+    64, 68, 70, 72, 74, 76, 84, 86, 90, 92, 96, 100, 104, 108, 112, 116, 120,
+    124, 132, 136, 140, 144, 148, 152, 156, 158, 162, 166, 170, 174, 175, 178,
+    180, 184, 188, 191, 192, 196, 203, 204, 208, 212, 214, 218, 222, 226, 231,
+    232, 233, 234, 238, 239, 242, 246, 248, 250, 254, 258, 260, 262, 266, 268,
+    270, 275, 276, 288, 292, 296, 300, 304, 308, 312, 316, 320, 324, 328, 332,
+    334, 336, 340, 344, 348, 352, 356, 360, 364, 368, 372, 376, 380, 384, 388,
+    392, 398, 400, 404, 408, 410, 414, 417, 418, 422, 426, 428, 430, 434, 438,
+    440, 442, 446, 450, 454, 458, 462, 466, 470, 474, 478, 480, 484, 492, 496,
+    498, 499, 500, 504, 508, 512, 516, 520, 524, 528, 531, 533, 534, 535, 540,
+    548, 554, 558, 562, 566, 570, 574, 578, 580, 581, 583, 584, 585, 586, 591,
+    598, 600, 604, 608, 612, 616, 620, 624, 626, 630, 634, 638, 642, 643, 646,
+    652, 654, 659, 660, 662, 663, 666, 670, 674, 678, 682, 686, 688, 690, 694,
+    702, 703, 704, 705, 706, 710, 716, 724, 728, 729, 732, 740, 744, 748, 752,
+    756, 760, 762, 764, 768, 772, 776, 780, 784, 788, 792, 795, 796, 798, 800,
+    804, 807, 818, 826, 831, 832, 833, 834, 840, 850, 854, 858, 860, 862, 876,
+    882, 887, 894
+]
+
+
+def _s3_loader(
+    dist_zarr_uri: str,
+) -> Tuple[xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset]:
+
+    dist_alerts = xr.open_zarr(dist_zarr_uri)
+
+    country = xr.open_zarr(country_zarr_uri)
+    country_aligned = xr.align(dist_alerts, country, join='left')[1]
+    region = xr.open_zarr(region_zarr_uri)
+    region_aligned = xr.align(dist_alerts, region, join='left')[1]
+    subregion = xr.open_zarr(subregion_zarr_uri)
+    subregion_aligned = xr.align(dist_alerts, subregion, join='left')[1]
+
+    dist_drivers = xr.open_zarr(
+        f"s3://{DATA_LAKE_BUCKET}/umd_glad_dist_alerts_driver/zarr/umd_dist_alerts_drivers.zarr"
+    )
+    dist_drivers_aligned = xr.align(dist_alerts, dist_drivers, join='left')[1]
+
+    return (
+        dist_alerts,
+        country_aligned,
+        region_aligned,
+        subregion_aligned,
+        dist_drivers_aligned,
+    )
+
+
+def _parquet_saver(alerts_count_df: pd.DataFrame, results_uri: str) -> None:
+    alerts_count_df.to_parquet(results_uri, index=False)
+
+
+def gadm_dist_alerts_by_driver(
+    dist_zarr_uri: str,
+    dist_version: str,
+    loader: LoaderType = _s3_loader,
+    groups: Optional[ExpectedGroupsType] = None,
+    saver: SaverType = _parquet_saver,
+    overwrite: bool = False
+) -> str:
     """Run DIST alerts analysis by driver using Dask to create parquet, upload to S3 and return URI."""
-    results_key = f"umd_glad_dist_alerts/{version}/tabular/epsg-4326/zonal_stats/dist_alerts_by_adm2_driver.parquet"
+    results_key = f"umd_glad_dist_alerts/{dist_version}/tabular/epsg-4326/zonal_stats/dist_alerts_by_adm2_driver.parquet"
     results_uri = f"s3://{DATA_LAKE_BUCKET}/{results_key}"
 
     if not overwrite and s3_object_exists(DATA_LAKE_BUCKET, results_key):
@@ -18,90 +85,84 @@ def gadm_dist_alerts_by_driver(zarr_uri: str, version: str, overwrite: bool) -> 
 
     logging.getLogger("distributed.client").setLevel(logging.ERROR)
 
-    dist_alerts = xr.open_zarr(zarr_uri)
-
-    country = xr.open_zarr(country_zarr_uri)
-    country_from_clipped = xr.align(dist_alerts, country, join='left')[1].band_data
-    region = xr.open_zarr(region_zarr_uri)
-    region_from_clipped = xr.align(dist_alerts, region, join='left')[1].band_data
-    subregion = xr.open_zarr(subregion_zarr_uri)
-    subregion_from_clipped = xr.align(dist_alerts, subregion, join='left')[1].band_data
-
-    # This is actually an already-clipped versions of drivers
-    dist_drivers = xr.open_zarr(
-        f"s3://{DATA_LAKE_BUCKET}/umd_glad_dist_alerts_driver/zarr/umd_dist_alerts_drivers.zarr"
+    return pipe(
+        loader(dist_zarr_uri),
+        lambda d: _setup(*d, groups),
+        lambda s: _compute(*s),
+        _create_data_frame,
+        lambda df: _save_results(df, dist_version, saver, results_uri),
     )
-    dist_drivers_from_clipped = xr.align(dist_alerts, dist_drivers, join='left')[1].band_data
 
-    adm0_ids = [
-        0, 4, 8, 10, 12, 16, 20, 24, 28, 31, 32, 36, 40, 44, 48, 50, 51, 52, 56, 60,
-        64, 68, 70, 72, 74, 76, 84, 86, 90, 92, 96, 100, 104, 108, 112, 116, 120,
-        124, 132, 136, 140, 144, 148, 152, 156, 158, 162, 166, 170, 174, 175, 178,
-        180, 184, 188, 191, 192, 196, 203, 204, 208, 212, 214, 218, 222, 226, 231,
-        232, 233, 234, 238, 239, 242, 246, 248, 250, 254, 258, 260, 262, 266, 268,
-        270, 275, 276, 288, 292, 296, 300, 304, 308, 312, 316, 320, 324, 328, 332,
-        334, 336, 340, 344, 348, 352, 356, 360, 364, 368, 372, 376, 380, 384, 388,
-        392, 398, 400, 404, 408, 410, 414, 417, 418, 422, 426, 428, 430, 434, 438,
-        440, 442, 446, 450, 454, 458, 462, 466, 470, 474, 478, 480, 484, 492, 496,
-        498, 499, 500, 504, 508, 512, 516, 520, 524, 528, 531, 533, 534, 535, 540,
-        548, 554, 558, 562, 566, 570, 574, 578, 580, 581, 583, 584, 585, 586, 591,
-        598, 600, 604, 608, 612, 616, 620, 624, 626, 630, 634, 638, 642, 643, 646,
-        652, 654, 659, 660, 662, 663, 666, 670, 674, 678, 682, 686, 688, 690, 694,
-        702, 703, 704, 705, 706, 710, 716, 724, 728, 729, 732, 740, 744, 748, 752,
-        756, 760, 762, 764, 768, 772, 776, 780, 784, 788, 792, 795, 796, 798, 800,
-        804, 807, 818, 826, 831, 832, 833, 834, 840, 850, 854, 858, 860, 862, 876,
-        882, 887, 894
-    ]
 
-    alert_dates = np.arange(731, 1590)
+def _setup(
+    dist_alerts: xr.Dataset,
+    country: xr.Dataset,
+    region: xr.Dataset,
+    subregion: xr.Dataset,
+    dist_drivers: xr.Dataset,
+    expected_groups: Tuple,
+) -> Tuple:
+    groups = (
+        (
+            np.arange(894),        # country ISO codes
+            np.arange(86),         # region codes
+            np.arange(854),        # subregion codes
+            np.arange(5),          # driver categories
+            np.arange(731, 1590),  # days
+            [1, 2, 3],             # confidence values
+        )
+        if expected_groups is None
+        else expected_groups
+    )
 
-    country_from_clipped.name = "countries"
-    region_from_clipped.name = "regions"
-    subregion_from_clipped.name = "subregions"
-    dist_drivers_from_clipped.name = "driver"
-    print("Starting reduce")
-    alerts_count = xarray_reduce(
+    return (
         dist_alerts.confidence,
-        *(
-            country_from_clipped,
-            region_from_clipped,
-            subregion_from_clipped,
-            dist_drivers_from_clipped,
+        (
+            country.band_data.rename("country"),
+            region.band_data.rename("region"),
+            subregion.band_data.rename("subregion"),
+            dist_drivers.band_data.rename("driver"),
             dist_alerts.alert_date,
-            dist_alerts.confidence
+            dist_alerts.confidence,
         ),
-        func='count',
-        expected_groups=(
-            adm0_ids,
-            np.arange(86),
-            np.arange(854),
-            np.arange(5),
-            alert_dates,
-            [1, 2, 3]
-        ),
+        groups,
+    )
+
+
+def _compute(reduce_mask: xr.DataArray, reduce_groupbys: Tuple, expected_groups: Tuple):
+    return xarray_reduce(
+        reduce_mask,
+        *reduce_groupbys,
+        func="count",
+        expected_groups=expected_groups,
         reindex=ReindexStrategy(
             blockwise=False, array_type=ReindexArrayType.SPARSE_COO
         ),
-        fill_value=0
+        fill_value=0,
     ).compute()
-    print("Finished reduce")
 
+
+def _create_data_frame(alerts_count: xr.Dataset) -> pd.DataFrame:
     sparse_data = alerts_count.data
-
     dim_names = alerts_count.dims
     indices = sparse_data.coords
     values = sparse_data.data
 
     coord_dict = {
-        dim: alerts_count.coords[dim].values[indices[i]]
-        for i, dim in enumerate(dim_names)
+        dim: alerts_count.coords[dim].values[idx]
+        for dim, idx in zip(dim_names, indices)
     }
     coord_dict["value"] = values
 
-    df = pd.DataFrame(coord_dict)
+    return pd.DataFrame(coord_dict)
 
-    df = pd.DataFrame(coord_dict)
-    print("Starting parquet")
-    df.to_parquet(results_uri, index=False)
-    print("Finished parquet")
+
+def _save_results(
+    alerts_count_df: pd.DataFrame, dist_version: str, saver: Callable, results_uri: str
+) -> str:
+    saver(alerts_count_df, results_uri)
     return results_uri
+
+
+def pipe(value, *functions):
+    return reduce(lambda v, f: f(v), functions, value)

--- a/pipelines/disturbance/gadm_dist_alerts_by_driver.py
+++ b/pipelines/disturbance/gadm_dist_alerts_by_driver.py
@@ -28,9 +28,10 @@ def gadm_dist_alerts_by_driver(zarr_uri: str, version: str, overwrite: bool) -> 
     subregion_from_clipped = xr.align(dist_alerts, subregion, join='left')[1].band_data
 
     # This is actually an already-clipped versions of drivers
-    dist_drivers_from_clipped = xr.open_zarr(
+    dist_drivers = xr.open_zarr(
         f"s3://{DATA_LAKE_BUCKET}/umd_glad_dist_alerts_driver/zarr/umd_dist_alerts_drivers.zarr"
-    ).band_data
+    )
+    dist_drivers_from_clipped = xr.align(dist_alerts, dist_drivers, join='left')[1].band_data
 
     adm0_ids = [
         0, 4, 8, 10, 12, 16, 20, 24, 28, 31, 32, 36, 40, 44, 48, 50, 51, 52, 56, 60,

--- a/pipelines/disturbance/gadm_dist_alerts_by_natural_lands.py
+++ b/pipelines/disturbance/gadm_dist_alerts_by_natural_lands.py
@@ -1,15 +1,59 @@
-import numpy as np
-import xarray as xr
-import pandas as pd
 import logging
-from flox.xarray import xarray_reduce
+from functools import reduce
+from typing import Callable, Tuple, Optional
+import numpy as np
+import pandas as pd
+import xarray as xr
 from flox import ReindexArrayType, ReindexStrategy
+from flox.xarray import xarray_reduce
 
 from .check_for_new_alerts import s3_object_exists
 from ..globals import DATA_LAKE_BUCKET, country_zarr_uri, region_zarr_uri, subregion_zarr_uri
 
-def gadm_dist_alerts_by_natural_lands(zarr_uri: str, version: str, overwrite: bool) -> str:
+LoaderType = Callable[[str], Tuple[xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset]]
+ExpectedGroupsType = Tuple
+SaverType = Callable[[pd.DataFrame, str], None]
+
+def _s3_loader(
+    dist_zarr_uri: str,
+) -> Tuple[xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset]:
+
+    dist_alerts = xr.open_zarr(dist_zarr_uri)
+
+    country = xr.open_zarr(country_zarr_uri)
+    country_aligned = xr.align(dist_alerts, country, join='left')[1]
+    region = xr.open_zarr(region_zarr_uri)
+    region_aligned = xr.align(dist_alerts, region, join='left')[1]
+    subregion = xr.open_zarr(subregion_zarr_uri)
+    subregion_aligned = xr.align(dist_alerts, subregion, join='left')[1]
+
+    natural_lands = xr.open_zarr(
+        f's3://{DATA_LAKE_BUCKET}/sbtn_natural_lands/zarr/sbtn_natural_lands_all_classes.zarr'
+    )
+    natural_lands_aligned = xr.align(dist_alerts, natural_lands, join='left')[1]
+
+    return (
+        dist_alerts,
+        country_aligned,
+        region_aligned,
+        subregion_aligned,
+        natural_lands_aligned
+    )
+
+def _parquet_saver(alerts_count_df: pd.DataFrame, results_uri: str) -> None:
+    alerts_count_df.to_parquet(results_uri, index=False)
+
+
+def gadm_dist_alerts_by_natural_lands(
+    zarr_uri: str,
+    version: str,
+    loader: LoaderType = _s3_loader,
+    groups: Optional[ExpectedGroupsType] = None,
+    saver: SaverType = _parquet_saver,
+    overwrite: bool = False
+) -> str:
     """Run DIST alerts analysis by natural lands using Dask to create parquet, upload to S3 and return URI."""
+    logging.getLogger("distributed.client").setLevel(logging.ERROR)
 
     results_key = f"umd_glad_dist_alerts/{version}/tabular/epsg-4326/zonal_stats/dist_alerts_by_adm2_natural_lands.parquet"
     results_uri = f"s3://{DATA_LAKE_BUCKET}/{results_key}"
@@ -17,88 +61,86 @@ def gadm_dist_alerts_by_natural_lands(zarr_uri: str, version: str, overwrite: bo
     if not overwrite and s3_object_exists(DATA_LAKE_BUCKET, results_key):
         return results_uri
 
-    logging.getLogger("distributed.client").setLevel(logging.ERROR)
-
-    dist_alerts = xr.open_zarr(zarr_uri)
-    country = xr.open_zarr(country_zarr_uri)
-    country_from_clipped = xr.align(dist_alerts, country, join='left')[1].band_data
-    region = xr.open_zarr(region_zarr_uri)
-    region_from_clipped = xr.align(dist_alerts, region, join='left')[1].band_data
-    subregion = xr.open_zarr(subregion_zarr_uri)
-    subregion_from_clipped = xr.align(dist_alerts, subregion, join='left')[1].band_data
-
-    natural_lands = xr.open_zarr(
-        f's3://{DATA_LAKE_BUCKET}/sbtn_natural_lands/zarr/sbtn_natural_lands_all_classes.zarr'
+    return pipe(
+        loader(zarr_uri),
+        lambda d: _setup(*d, groups),
+        lambda s: _compute(*s),
+        _create_data_frame,
+        lambda df: _save_results(df, version, saver, results_uri),
     )
-    natural_lands_from_clipped = xr.align(dist_alerts, natural_lands, join='left')[1].band_data
 
-    adm0_ids = [
-        0, 4, 8, 10, 12, 16, 20, 24, 28, 31, 32, 36, 40, 44, 48, 50, 51, 52, 56, 60,
-        64, 68, 70, 72, 74, 76, 84, 86, 90, 92, 96, 100, 104, 108, 112, 116, 120,
-        124, 132, 136, 140, 144, 148, 152, 156, 158, 162, 166, 170, 174, 175, 178,
-        180, 184, 188, 191, 192, 196, 203, 204, 208, 212, 214, 218, 222, 226, 231,
-        232, 233, 234, 238, 239, 242, 246, 248, 250, 254, 258, 260, 262, 266, 268,
-        270, 275, 276, 288, 292, 296, 300, 304, 308, 312, 316, 320, 324, 328, 332,
-        334, 336, 340, 344, 348, 352, 356, 360, 364, 368, 372, 376, 380, 384, 388,
-        392, 398, 400, 404, 408, 410, 414, 417, 418, 422, 426, 428, 430, 434, 438,
-        440, 442, 446, 450, 454, 458, 462, 466, 470, 474, 478, 480, 484, 492, 496,
-        498, 499, 500, 504, 508, 512, 516, 520, 524, 528, 531, 533, 534, 535, 540,
-        548, 554, 558, 562, 566, 570, 574, 578, 580, 581, 583, 584, 585, 586, 591,
-        598, 600, 604, 608, 612, 616, 620, 624, 626, 630, 634, 638, 642, 643, 646,
-        652, 654, 659, 660, 662, 663, 666, 670, 674, 678, 682, 686, 688, 690, 694,
-        702, 703, 704, 705, 706, 710, 716, 724, 728, 729, 732, 740, 744, 748, 752,
-        756, 760, 762, 764, 768, 772, 776, 780, 784, 788, 792, 795, 796, 798, 800,
-        804, 807, 818, 826, 831, 832, 833, 834, 840, 850, 854, 858, 860, 862, 876,
-        882, 887, 894
-    ]
-
-    alert_dates = np.arange(731, 1590)  # we should get this from metadata which includes `content_date_range`
-
-    country_from_clipped.name = "countries"
-    region_from_clipped.name = "regions"
-    subregion_from_clipped.name = "subregions"
-    natural_lands_from_clipped.name = "natural_lands"
-    print("Starting reduce")
-    alerts_count = xarray_reduce(
-        dist_alerts.confidence,
-        *(
-            country_from_clipped,
-            region_from_clipped,
-            subregion_from_clipped,
-            natural_lands_from_clipped,
-            dist_alerts.alert_date,
-            dist_alerts.confidence
-        ),
-        func='count',
-        expected_groups=(
-            adm0_ids,
+def _setup(
+    dist_alerts: xr.Dataset,
+    country: xr.Dataset,
+    region: xr.Dataset,
+    subregion: xr.Dataset,
+    dist_natural_lands: xr.Dataset,
+    expected_groups: Tuple,
+) -> Tuple:
+    groups = (
+        (
+            np.arange(894),
             np.arange(86),
             np.arange(854),
-            np.arange(22),
-            alert_dates,
-            [1, 2, 3]
+            np.arange(22), # natural lands categories
+            # we should get this from metadata which includes `content_date_range`
+            np.arange(731, 1590),
+            [1, 2, 3],
+        )
+        if expected_groups is None
+        else expected_groups
+    )
+    return (
+        dist_alerts.confidence,
+        (
+            country.band_data.rename("country"),
+            region.band_data.rename("region"),
+            subregion.band_data.rename("subregion"),
+            dist_natural_lands.band_data.rename("natural_lands"),
+            dist_alerts.alert_date,
+            dist_alerts.confidence,
         ),
+        groups,
+    )
+
+
+def _compute(reduce_mask: xr.DataArray, reduce_groupbys: Tuple, expected_groups: Tuple):
+    print("Starting reduce")
+    alerts_count = xarray_reduce(
+        reduce_mask,
+        *reduce_groupbys,
+        func="count",
+        expected_groups=expected_groups,
         reindex=ReindexStrategy(
             blockwise=False, array_type=ReindexArrayType.SPARSE_COO
         ),
-        fill_value=0
+        fill_value=0,
     ).compute()
     print("Finished reduce")
+    return alerts_count
 
+def _create_data_frame(alerts_count: xr.Dataset) -> pd.DataFrame:
     sparse_data = alerts_count.data
-
     dim_names = alerts_count.dims
     indices = sparse_data.coords
     values = sparse_data.data
 
     coord_dict = {
-        dim: alerts_count.coords[dim].values[indices[i]]
-        for i, dim in enumerate(dim_names)
+        dim: alerts_count.coords[dim].values[idx]
+        for dim, idx in zip(dim_names, indices)
     }
     coord_dict["value"] = values
 
-    df = pd.DataFrame(coord_dict)
+    return pd.DataFrame(coord_dict)
+
+def _save_results(
+    alerts_count_df: pd.DataFrame, dist_version: str, saver: Callable, results_uri: str
+) -> str:
     print("Starting parquet")
-    df.to_parquet(results_uri, index=False)
+    saver(alerts_count_df, results_uri)
     print("Finished parquet")
     return results_uri
+
+
+def pipe(value, *functions):
+    return reduce(lambda v, f: f(v), functions, value)

--- a/pipelines/disturbance/gadm_dist_alerts_by_natural_lands.py
+++ b/pipelines/disturbance/gadm_dist_alerts_by_natural_lands.py
@@ -1,51 +1,11 @@
 import logging
-from functools import reduce
-from typing import Callable, Tuple, Optional
+from typing import Optional
 import numpy as np
-import pandas as pd
-import xarray as xr
-from flox import ReindexArrayType, ReindexStrategy
-from flox.xarray import xarray_reduce
 
 from .check_for_new_alerts import s3_object_exists
-from ..globals import DATA_LAKE_BUCKET, country_zarr_uri, region_zarr_uri, subregion_zarr_uri
+from ..globals import DATA_LAKE_BUCKET
 
-LoaderType = Callable[[str, Optional[str]], Tuple[xr.Dataset, ...]]
-ExpectedGroupsType = Tuple
-SaverType = Callable[[pd.DataFrame, str], None]
-
-def _s3_loader(
-    dist_zarr_uri: str,
-    contextual_uri: Optional[str],
-) -> Tuple[xr.Dataset, ...]:
-    """Load in the Dist alert Zarr, the GADM zarrs, and possibly a contextual layer zarr"""
-
-    dist_alerts = xr.open_zarr(dist_zarr_uri)
-
-    country = xr.open_zarr(country_zarr_uri)
-    country_aligned = xr.align(dist_alerts, country, join='left')[1]
-    region = xr.open_zarr(region_zarr_uri)
-    region_aligned = xr.align(dist_alerts, region, join='left')[1]
-    subregion = xr.open_zarr(subregion_zarr_uri)
-    subregion_aligned = xr.align(dist_alerts, subregion, join='left')[1]
-
-    if contextual_uri is not None:
-        contextual_layer = xr.open_zarr(contextual_uri)
-        contextual_layer_aligned = xr.align(dist_alerts, contextual_layer, join='left')[1]
-    else:
-        contextual_layer_aligned = None
-
-    return (
-        dist_alerts,
-        country_aligned,
-        region_aligned,
-        subregion_aligned,
-        contextual_layer_aligned
-    )
-
-def _parquet_saver(alerts_count_df: pd.DataFrame, results_uri: str) -> None:
-    alerts_count_df.to_parquet(results_uri, index=False)
-
+from .stages import LoaderType, ExpectedGroupsType, SaverType, _s3_loader, _parquet_saver, _setup, _compute, _create_data_frame, _save_results, pipe
 
 def gadm_dist_alerts_by_natural_lands(
     dist_zarr_uri: str,
@@ -88,66 +48,3 @@ def gadm_dist_alerts_by_natural_lands(
         _create_data_frame,
         lambda df: _save_results(df, dist_version, saver, results_uri),
     )
-
-def _setup(
-    datasets: Tuple[xr.Dataset, ...],
-    expected_groups: Optional[ExpectedGroupsType],
-    contextual_column_name: Optional[str]
-) -> Tuple:
-    """Setup the arguments for the xrarray reduce on dist alerts"""
-    dist_alerts, country, region, subregion, contextual_layer = datasets
-
-    mask = dist_alerts.confidence
-    groupbys: Tuple[xr.Dataset, ...] = (
-        country.band_data.rename("country"),
-        region.band_data.rename("region"),
-        subregion.band_data.rename("subregion"),
-        dist_alerts.alert_date,
-        dist_alerts.confidence,
-    )
-    if contextual_layer is not None:
-        groupbys = groupbys[:2] + (contextual_layer.band_data.rename(contextual_column_name),) + groupbys[2:]
-
-    return (mask, groupbys, expected_groups)
-
-
-def _compute(reduce_mask: xr.DataArray, reduce_groupbys: Tuple, expected_groups: Tuple):
-    print("Starting reduce")
-    alerts_count = xarray_reduce(
-        reduce_mask,
-        *reduce_groupbys,
-        func="count",
-        expected_groups=expected_groups,
-        reindex=ReindexStrategy(
-            blockwise=False, array_type=ReindexArrayType.SPARSE_COO
-        ),
-        fill_value=0,
-    ).compute()
-    print("Finished reduce")
-    return alerts_count
-
-def _create_data_frame(alerts_count: xr.Dataset) -> pd.DataFrame:
-    sparse_data = alerts_count.data
-    dim_names = alerts_count.dims
-    indices = sparse_data.coords
-    values = sparse_data.data
-
-    coord_dict = {
-        dim: alerts_count.coords[dim].values[idx]
-        for dim, idx in zip(dim_names, indices)
-    }
-    coord_dict["value"] = values
-
-    return pd.DataFrame(coord_dict)
-
-def _save_results(
-    alerts_count_df: pd.DataFrame, dist_version: str, saver: Callable, results_uri: str
-) -> str:
-    print("Starting parquet")
-    saver(alerts_count_df, results_uri)
-    print("Finished parquet")
-    return results_uri
-
-
-def pipe(value, *functions):
-    return reduce(lambda v, f: f(v), functions, value)

--- a/pipelines/disturbance/gadm_dist_alerts_by_natural_lands.py
+++ b/pipelines/disturbance/gadm_dist_alerts_by_natural_lands.py
@@ -26,7 +26,7 @@ def gadm_dist_alerts_by_natural_lands(
             np.arange(86),         # region codes
             np.arange(854),        # subregion codes
             np.arange(22),         # natural lands categories
-            np.arange(731, 1590),  # date range
+            np.arange(731, 1590),  # dates values
             [1, 2, 3],             # confidence values
         )
         if groups is None

--- a/pipelines/disturbance/stages.py
+++ b/pipelines/disturbance/stages.py
@@ -1,0 +1,107 @@
+from functools import reduce
+from typing import Callable, Tuple, Optional
+import pandas as pd
+import xarray as xr
+from flox import ReindexArrayType, ReindexStrategy
+from flox.xarray import xarray_reduce
+
+from ..globals import country_zarr_uri, region_zarr_uri, subregion_zarr_uri
+
+LoaderType = Callable[[str, Optional[str]], Tuple[xr.Dataset, ...]]
+ExpectedGroupsType = Tuple
+SaverType = Callable[[pd.DataFrame, str], None]
+
+def _s3_loader(
+    dist_zarr_uri: str,
+    contextual_uri: Optional[str],
+) -> Tuple[xr.Dataset, ...]:
+    """Load in the Dist alert Zarr, the GADM zarrs, and possibly a contextual layer zarr"""
+
+    dist_alerts = xr.open_zarr(dist_zarr_uri)
+
+    country = xr.open_zarr(country_zarr_uri)
+    country_aligned = xr.align(dist_alerts, country, join='left')[1]
+    region = xr.open_zarr(region_zarr_uri)
+    region_aligned = xr.align(dist_alerts, region, join='left')[1]
+    subregion = xr.open_zarr(subregion_zarr_uri)
+    subregion_aligned = xr.align(dist_alerts, subregion, join='left')[1]
+
+    if contextual_uri is not None:
+        contextual_layer = xr.open_zarr(contextual_uri)
+        contextual_layer_aligned = xr.align(dist_alerts, contextual_layer, join='left')[1]
+    else:
+        contextual_layer_aligned = None
+
+    return (
+        dist_alerts,
+        country_aligned,
+        region_aligned,
+        subregion_aligned,
+        contextual_layer_aligned
+    )
+
+def _parquet_saver(alerts_count_df: pd.DataFrame, results_uri: str) -> None:
+    alerts_count_df.to_parquet(results_uri, index=False)
+
+def _setup(
+    datasets: Tuple[xr.Dataset, ...],
+    expected_groups: Optional[ExpectedGroupsType],
+    contextual_column_name: Optional[str]
+) -> Tuple:
+    """Setup the arguments for the xrarray reduce on dist alerts"""
+    dist_alerts, country, region, subregion, contextual_layer = datasets
+
+    mask = dist_alerts.confidence
+    groupbys: Tuple[xr.Dataset, ...] = (
+        country.band_data.rename("country"),
+        region.band_data.rename("region"),
+        subregion.band_data.rename("subregion"),
+        dist_alerts.alert_date,
+        dist_alerts.confidence,
+    )
+    if contextual_layer is not None:
+        groupbys = groupbys[:2] + (contextual_layer.band_data.rename(contextual_column_name),) + groupbys[2:]
+
+    return (mask, groupbys, expected_groups)
+
+
+def _compute(reduce_mask: xr.DataArray, reduce_groupbys: Tuple, expected_groups: Tuple):
+    print("Starting reduce")
+    alerts_count = xarray_reduce(
+        reduce_mask,
+        *reduce_groupbys,
+        func="count",
+        expected_groups=expected_groups,
+        reindex=ReindexStrategy(
+            blockwise=False, array_type=ReindexArrayType.SPARSE_COO
+        ),
+        fill_value=0,
+    ).compute()
+    print("Finished reduce")
+    return alerts_count
+
+def _create_data_frame(alerts_count: xr.Dataset) -> pd.DataFrame:
+    sparse_data = alerts_count.data
+    dim_names = alerts_count.dims
+    indices = sparse_data.coords
+    values = sparse_data.data
+
+    coord_dict = {
+        dim: alerts_count.coords[dim].values[idx]
+        for dim, idx in zip(dim_names, indices)
+    }
+    coord_dict["value"] = values
+
+    return pd.DataFrame(coord_dict)
+
+def _save_results(
+    alerts_count_df: pd.DataFrame, dist_version: str, saver: Callable, results_uri: str
+) -> str:
+    print("Starting parquet")
+    saver(alerts_count_df, results_uri)
+    print("Finished parquet")
+    return results_uri
+
+
+def pipe(value, *functions):
+    return reduce(lambda v, f: f(v), functions, value)

--- a/test/pipelines/disturbance/conftest.py
+++ b/test/pipelines/disturbance/conftest.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 import numpy as np
 import xarray as xr
-
+from typing import Optional
 
 @pytest.fixture
 def expected_groups():
@@ -18,7 +18,7 @@ def expected_groups():
 
 @pytest.fixture
 def mock_loader():
-    def _loader(dist_zarr_uri: str):
+    def _loader(dist_zarr_uri: str, contextual_uri: Optional[str]):
         # 1. dist_alerts dataset
         confidence_data = np.array([[[3, 2], [2, 3]]], dtype=np.int16)
         alert_date_data = np.array([[[750, 731], [731, 800]]], dtype=np.int16)
@@ -64,7 +64,7 @@ def mock_loader():
             },
         )
 
-        return dist_alerts, country, region, subregion
+        return dist_alerts, country, region, subregion, None
 
     return _loader
 

--- a/test/pipelines/disturbance/test_gadm_dist_alerts_by_driver.py
+++ b/test/pipelines/disturbance/test_gadm_dist_alerts_by_driver.py
@@ -1,0 +1,145 @@
+import numpy as np
+import pytest
+import xarray as xr
+from pandera.pandas import DataFrameSchema, Column, Check
+from pipelines.disturbance.gadm_dist_alerts_by_driver import gadm_dist_alerts_by_driver
+
+
+@pytest.fixture
+def expected_groups_driver():
+    return (
+        # Match expected groups to minimal data values
+        [12],  # Country values in minimal data
+        [7],  # Region values
+        [124, 125],  # Subregion values
+        np.arange(5), # all the driver categories
+        [731, 750, 800],  # Alert date values in minimal data
+        [2, 3],  # Confidence values in minimal data
+    )
+
+
+@pytest.fixture
+def mock_loader_driver():
+    def _loader(dist_zarr_uri: str):
+        # 1. dist_alerts dataset
+        confidence_data = np.array([[[3, 2], [2, 3]]], dtype=np.int16)
+        alert_date_data = np.array([[[750, 731], [731, 800]]], dtype=np.int16)
+        dist_alerts = xr.Dataset(
+            data_vars={
+                "confidence": (("band", "y", "x"), confidence_data),
+                "alert_date": (("band", "y", "x"), alert_date_data),
+            },
+            coords={
+                "band": ("band", [1], {}),
+                "y": ("y", [60.0, 59.99975], {}),
+                "x": ("x", [-180.0, -179.99975], {}),
+                "spatial_ref": ((), 0, {}),
+            },
+            attrs={},
+        )
+
+        # 2. GADM datasets
+        country = xr.Dataset(
+            data_vars={
+                "band_data": (
+                    ("band", "y", "x"),
+                    np.array([[[12, 12], [12, 12]]], dtype=np.uint16),
+                )
+            },
+        )
+
+        region = xr.Dataset(
+            data_vars={
+                "band_data": (
+                    ("band", "y", "x"),
+                    np.array([[[7, 7], [7, 7]]], dtype=np.uint16),
+                )
+            },
+        )
+
+        subregion = xr.Dataset(
+            data_vars={
+                "band_data": (
+                    ("band", "y", "x"),
+                    np.array([[[124, 124], [124, 125]]], dtype=np.uint16),
+                )
+            },
+        )
+
+        driver = xr.Dataset(
+            data_vars={
+                "band_data": (
+                    ("band", "y", "x"),
+                    np.array([[[2, 2], [2, 2]]], dtype=np.uint8),
+                )
+            },
+        )
+
+        return dist_alerts, country, region, subregion, driver
+
+    return _loader
+
+
+def test_gadm_dist_alerts_by_driver_happy_path(
+    mock_loader_driver, expected_groups_driver, spy_saver
+):
+    """Test full workflow with in-memory dependencies"""
+    result_uri = gadm_dist_alerts_by_driver(
+        dist_zarr_uri="s3://dummy_zarr_uri",
+        dist_version="test_v1",
+        loader=mock_loader_driver,
+        groups=expected_groups_driver,
+        saver=spy_saver,
+        overwrite=True,
+    )
+
+    assert (
+        result_uri
+        == "s3://gfw-data-lake/umd_glad_dist_alerts/test_v1/tabular/epsg-4326/zonal_stats/dist_alerts_by_adm2_driver.parquet"
+    )
+
+
+def test_gadm_dist_alerts_by_driver_result(mock_loader_driver, expected_groups_driver, spy_saver):
+    alert_schema = DataFrameSchema(
+        name="GADM Dist Alerts",
+        columns={
+            "country": Column(int, Check.ge(0)),
+            "region": Column(int, Check.ge(0)),
+            "subregion": Column(int, Check.ge(0)),
+            "driver": Column(int, Check.ge(0)),
+            "alert_date": Column(
+                int,
+                checks=[
+                    Check.greater_than_or_equal_to(731),
+                    Check.less_than_or_equal_to(800),
+                ],
+            ),
+            "confidence": Column(int, Check.isin([2, 3])),
+            "value": Column(int, Check.isin([0, 1, 2])),
+        },
+        unique=["country", "region", "subregion", "driver", "alert_date", "confidence"],
+        checks=Check(
+            lambda df: (
+                df.groupby(["country", "region", "subregion", "driver", "alert_date"])[
+                    "confidence"
+                ].transform("nunique")
+                == 2
+            ),
+            name="two_confidences_per_group",
+            error="Each location-date must have exactly 2 confidence levels",
+        ),
+    )
+
+    gadm_dist_alerts_by_driver(
+        dist_zarr_uri="s3://dummy_zarr_uri",
+        dist_version="test_v1",
+        loader=mock_loader_driver,
+        groups=expected_groups_driver,
+        saver=spy_saver,
+        overwrite=True,
+    )
+
+    # Verify
+    result = spy_saver.saved_data
+    print(f"\nGADM dist alerts result:\n{result}")
+    alert_schema.validate(result)

--- a/test/pipelines/disturbance/test_gadm_dist_alerts_by_driver.py
+++ b/test/pipelines/disturbance/test_gadm_dist_alerts_by_driver.py
@@ -3,6 +3,7 @@ import pytest
 import xarray as xr
 from pandera.pandas import DataFrameSchema, Column, Check
 from pipelines.disturbance.gadm_dist_alerts_by_driver import gadm_dist_alerts_by_driver
+from typing import Optional
 
 
 @pytest.fixture
@@ -20,7 +21,7 @@ def expected_groups_driver():
 
 @pytest.fixture
 def mock_loader_driver():
-    def _loader(dist_zarr_uri: str):
+    def _loader(dist_zarr_uri: str, contextual_uri: Optional[str]):
         # 1. dist_alerts dataset
         confidence_data = np.array([[[3, 2], [2, 3]]], dtype=np.int16)
         alert_date_data = np.array([[[750, 731], [731, 800]]], dtype=np.int16)

--- a/test/pipelines/disturbance/test_gadm_dist_alerts_by_natural_lands.py
+++ b/test/pipelines/disturbance/test_gadm_dist_alerts_by_natural_lands.py
@@ -3,6 +3,7 @@ from pipelines.disturbance.gadm_dist_alerts_by_natural_lands import gadm_dist_al
 import pytest
 import numpy as np
 import xarray as xr
+from typing import Optional
 
 
 @pytest.fixture
@@ -20,7 +21,7 @@ def expected_groups_nl():
 
 @pytest.fixture
 def mock_loader_nl():
-    def _loader(dist_zarr_uri: str):
+    def _loader(dist_zarr_uri: str, contextual_uri: Optional[str]):
         # 1. dist_alerts dataset
         confidence_data = np.array([[[3, 2], [2, 3]]], dtype=np.int16)
         alert_date_data = np.array([[[750, 731], [731, 800]]], dtype=np.int16)
@@ -82,8 +83,8 @@ def mock_loader_nl():
 def test_gadm_dist_alerts_happy_path(mock_loader_nl, expected_groups_nl, spy_saver):
     """Test full workflow with in-memory dependencies"""
     result_uri = gadm_dist_alerts_by_natural_lands(
-        zarr_uri="s3://dummy_zarr_uri",
-        version="test_v1",
+        dist_zarr_uri="s3://dummy_zarr_uri",
+        dist_version="test_v1",
         loader=mock_loader_nl,
         groups=expected_groups_nl,
         saver=spy_saver,
@@ -127,8 +128,8 @@ def test_gadm_dist_alerts_result(mock_loader_nl, expected_groups_nl, spy_saver):
     )
 
     gadm_dist_alerts_by_natural_lands(
-        zarr_uri="s3://dummy_zarr_uri",
-        version="test_v1",
+        dist_zarr_uri="s3://dummy_zarr_uri",
+        dist_version="test_v1",
         loader=mock_loader_nl,
         groups=expected_groups_nl,
         saver=spy_saver,

--- a/test/pipelines/disturbance/test_gadm_dist_alerts_by_natural_lands.py
+++ b/test/pipelines/disturbance/test_gadm_dist_alerts_by_natural_lands.py
@@ -1,0 +1,140 @@
+from pandera.pandas import DataFrameSchema, Column, Check
+from pipelines.disturbance.gadm_dist_alerts_by_natural_lands import gadm_dist_alerts_by_natural_lands
+import pytest
+import numpy as np
+import xarray as xr
+
+
+@pytest.fixture
+def expected_groups_nl():
+    return (
+        # Match expected groups to minimal data values
+        [12],  # Country values in minimal data
+        [7],  # Region values
+        [124, 125],  # Subregion values
+        [2],  # Natural lands values
+        [731, 750, 800],  # Alert date values in minimal data
+        [2, 3],  # Confidence values in minimal data
+    )
+
+
+@pytest.fixture
+def mock_loader_nl():
+    def _loader(dist_zarr_uri: str):
+        # 1. dist_alerts dataset
+        confidence_data = np.array([[[3, 2], [2, 3]]], dtype=np.int16)
+        alert_date_data = np.array([[[750, 731], [731, 800]]], dtype=np.int16)
+        dist_alerts = xr.Dataset(
+            data_vars={
+                "confidence": (("band", "y", "x"), confidence_data),
+                "alert_date": (("band", "y", "x"), alert_date_data),
+            },
+            coords={
+                "band": ("band", [1], {}),
+                "y": ("y", [60.0, 59.99975], {}),
+                "x": ("x", [-180.0, -179.99975], {}),
+                "spatial_ref": ((), 0, {}),
+            },
+            attrs={},
+        )
+
+        # 2. GADM datasets
+        country = xr.Dataset(
+            data_vars={
+                "band_data": (
+                    ("band", "y", "x"),
+                    np.array([[[12, 12], [12, 12]]], dtype=np.uint16),
+                )
+            },
+        )
+
+        region = xr.Dataset(
+            data_vars={
+                "band_data": (
+                    ("band", "y", "x"),
+                    np.array([[[7, 7], [7, 7]]], dtype=np.uint16),
+                )
+            },
+        )
+
+        subregion = xr.Dataset(
+            data_vars={
+                "band_data": (
+                    ("band", "y", "x"),
+                    np.array([[[124, 124], [124, 125]]], dtype=np.uint16),
+                )
+            },
+        )
+        natural_lands = xr.Dataset(
+            data_vars={
+                "band_data": (
+                    ("band", "y", "x"),
+                    np.array([[[2, 2], [2, 2]]], dtype=np.uint8),
+                )
+            },
+        )
+
+        return dist_alerts, country, region, subregion, natural_lands
+
+    return _loader
+
+
+def test_gadm_dist_alerts_happy_path(mock_loader_nl, expected_groups_nl, spy_saver):
+    """Test full workflow with in-memory dependencies"""
+    result_uri = gadm_dist_alerts_by_natural_lands(
+        zarr_uri="s3://dummy_zarr_uri",
+        version="test_v1",
+        loader=mock_loader_nl,
+        groups=expected_groups_nl,
+        saver=spy_saver,
+    )
+
+    assert (
+        result_uri
+        == "s3://gfw-data-lake/umd_glad_dist_alerts/test_v1/tabular/epsg-4326/zonal_stats/dist_alerts_by_adm2_natural_lands.parquet"
+    )
+
+
+def test_gadm_dist_alerts_result(mock_loader_nl, expected_groups_nl, spy_saver):
+    alert_schema = DataFrameSchema(
+        name="GADM Dist Alerts",
+        columns={
+            "country": Column(int, Check.ge(0)),
+            "region": Column(int, Check.ge(0)),
+            "subregion": Column(int, Check.ge(0)),
+            "natural_lands": Column(int, Check.ge(0)),
+            "alert_date": Column(
+                int,
+                checks=[
+                    Check.greater_than_or_equal_to(731),
+                    Check.less_than_or_equal_to(800),
+                ],
+            ),
+            "confidence": Column(int, Check.isin([2, 3])),
+            "value": Column(int, Check.isin([0, 1, 2])),
+        },
+        unique=["country", "region", "subregion", "natural_lands", "alert_date", "confidence"],
+        checks=Check(
+            lambda df: (
+                df.groupby(["country", "region", "subregion", "natural_lands", "alert_date"])[
+                    "confidence"
+                ].transform("nunique")
+                == 2
+            ),
+            name="two_confidences_per_group",
+            error="Each location-date must have exactly 2 confidence levels",
+        ),
+    )
+
+    gadm_dist_alerts_by_natural_lands(
+        zarr_uri="s3://dummy_zarr_uri",
+        version="test_v1",
+        loader=mock_loader_nl,
+        groups=expected_groups_nl,
+        saver=spy_saver,
+    )
+
+    # Verify
+    result = spy_saver.saved_data
+    print(f"\nGADM dist alerts result:\n{result}")
+    alert_schema.validate(result)


### PR DESCRIPTION
PZB-250 Refactor naturals, include drivers refactor from Daniel, then extract common code to stages.py

- Did PZB-250, refactoring natural_lands analysis like gadm_dist_alerts.py, added tests
- Incorporated Daniel's work for PZB-251, refactor drivers analysis like gadm_dist_alerts.py, added tests
- For now, we duplicated expected_groups() and mock_loader() fixtures for each analysis. That could be addressed in a later change if desired.
- Then I pulled out the varying parts of the pipeline functions as arguments passed by main gadm_dist_alerts*() file
 - Moved the now-common pipeline functions to stages.py, used them for all three dist analyses.  So, the dist analyses are now each just one main function.  The contextual layer and uri are specified as None if there isn't one.
 
You may want to look at stages.py first, to understand how I made the stages more generic, then look at the analysis files.

The tests all run successfully, and I also ran the full analyses on the latest dist alerts successfully.
 