### PR TITLE
PZB-295 (under PZB-252) Added natural lands flow.

### DIFF
--- a/pipelines/dist_flow.py
+++ b/pipelines/dist_flow.py
@@ -10,7 +10,7 @@ from pipelines.disturbance.create_zarr import (
 from pipelines.disturbance.check_for_new_alerts import get_latest_version
 
 from pipelines.disturbance import prefect_flows
-from pipelines.natural_lands import nl_flow
+from pipelines.natural_lands.prefect_flows import nl_flow as nl_prefect_flow
 
 logging.getLogger("distributed.client").setLevel(logging.ERROR)
 
@@ -59,7 +59,7 @@ def dist_alerts_flow(overwrite=False) -> list[str]:
         logger.info(f"Latest dist version: {dist_version}")
         dask_client, _ = create_cluster()
 
-        nl_result = nl_flow.gadm_natural_lands_area(overwrite=overwrite)
+        nl_result = nl_prefect_flow.gadm_natural_lands_area(overwrite=overwrite)
         result_uris.append(nl_result)
 
         dist_zarr_uri = create_zarr(dist_version, overwrite=overwrite)

--- a/pipelines/dist_flow.py
+++ b/pipelines/dist_flow.py
@@ -10,6 +10,7 @@ from pipelines.disturbance.create_zarr import (
 from pipelines.disturbance.check_for_new_alerts import get_latest_version
 
 from pipelines.disturbance import prefect_flows
+from pipelines.natural_lands import nl_flow
 
 logging.getLogger("distributed.client").setLevel(logging.ERROR)
 
@@ -57,6 +58,10 @@ def dist_alerts_flow(overwrite=False) -> list[str]:
         dist_version = get_new_dist_version()
         logger.info(f"Latest dist version: {dist_version}")
         dask_client, _ = create_cluster()
+
+        nl_result = nl_flow.gadm_natural_lands_area(overwrite=overwrite)
+        result_uris.append(nl_result)
+
         dist_zarr_uri = create_zarr(dist_version, overwrite=overwrite)
         gadm_dist_result = prefect_flows.dist_alerts_count(dist_zarr_uri, dist_version)
         result_uris.append(gadm_dist_result)

--- a/pipelines/disturbance/prefect_flows/dist_common_tasks.py
+++ b/pipelines/disturbance/prefect_flows/dist_common_tasks.py
@@ -22,8 +22,10 @@ def setup_compute(
 
 
 @task
-def compute_zonal_stat(dataset: xr.DataArray, groupbys: Tuple, expected_groups: Tuple):
-    return stages.compute(dataset, groupbys, expected_groups)
+def compute_zonal_stat(dataset: xr.DataArray, groupbys: Tuple, expected_groups: Tuple, funcname: str):
+    '''Do the reduction with the specified groupbys. funcname is the name of the
+    reduction function'''
+    return stages.compute(dataset, groupbys, expected_groups, funcname)
 
 
 @task

--- a/pipelines/disturbance/prefect_flows/dist_common_tasks.py
+++ b/pipelines/disturbance/prefect_flows/dist_common_tasks.py
@@ -1,15 +1,9 @@
 from typing import Optional, Tuple
 import xarray as xr
-import pandas as pd
 
 from prefect import task
 
 from pipelines.disturbance import stages
-
-
-@task
-def load_data(dist_zarr_uri: str, contextual_uri: Optional[str] = None):
-    return stages.load_data(dist_zarr_uri, contextual_uri)
 
 
 @task
@@ -19,20 +13,3 @@ def setup_compute(
     contextual_name: Optional[str] = None,
 ) -> Tuple:
     return stages.setup_compute(datasets, expected_groups, contextual_name)
-
-
-@task
-def compute_zonal_stat(dataset: xr.DataArray, groupbys: Tuple, expected_groups: Tuple, funcname: str):
-    '''Do the reduction with the specified groupbys. funcname is the name of the
-    reduction function'''
-    return stages.compute(dataset, groupbys, expected_groups, funcname)
-
-
-@task
-def postprocess_result(result: xr.Dataset):
-    return stages.create_result_dataframe(result)
-
-
-@task
-def save_result(result_df: pd.DataFrame, result_uri: str) -> str:
-    return stages.save_results(result_df, result_uri)

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts.py
@@ -29,7 +29,7 @@ def dist_alerts_count(dist_zarr_uri: str, dist_version: str, overwrite=False):
 
     result_dataset = dist_common_tasks.compute_zonal_stat.with_options(
         name="dist-alerts-compute-zonal-stats"
-    )(*compute_input)
+    )(*compute_input, funcname="count")
     result_df = dist_common_tasks.postprocess_result.with_options(
         name="dist-alerts-postprocess-result"
     )(result_dataset)

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts.py
@@ -5,6 +5,7 @@ from prefect import flow
 from pipelines.disturbance.prefect_flows import dist_common_tasks
 from pipelines.globals import DATA_LAKE_BUCKET
 from pipelines.utils import s3_uri_exists
+from pipelines.prefect_flows import common_tasks
 
 @flow(name="DIST alerts count")
 def dist_alerts_count(dist_zarr_uri: str, dist_version: str, overwrite=False):
@@ -20,20 +21,20 @@ def dist_alerts_count(dist_zarr_uri: str, dist_version: str, overwrite=False):
         np.arange(731, 1590),  # dates values
         [1, 2, 3],  # confidence values
     )
-    datasets = dist_common_tasks.load_data.with_options(name="dist-alerts-load_data")(
+    datasets = common_tasks.load_data.with_options(name="dist-alerts-load_data")(
         dist_zarr_uri
     )
     compute_input = dist_common_tasks.setup_compute.with_options(
         name="set-up-dist-alerts-compute"
     )(datasets, expected_groups)
 
-    result_dataset = dist_common_tasks.compute_zonal_stat.with_options(
+    result_dataset = common_tasks.compute_zonal_stat.with_options(
         name="dist-alerts-compute-zonal-stats"
     )(*compute_input, funcname="count")
-    result_df = dist_common_tasks.postprocess_result.with_options(
+    result_df = common_tasks.postprocess_result.with_options(
         name="dist-alerts-postprocess-result"
     )(result_dataset)
-    dist_common_tasks.save_result.with_options(
+    common_tasks.save_result.with_options(
         name="dist-alerts-save-result"
     )(result_df, result_uri)
 

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_drivers.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_drivers.py
@@ -5,6 +5,7 @@ from prefect import flow
 from pipelines.disturbance.prefect_flows import dist_common_tasks
 from pipelines.globals import DATA_LAKE_BUCKET
 from pipelines.utils import s3_uri_exists
+from pipelines.prefect_flows import common_tasks
 
 @flow(name="DIST alerts count by drivers")
 def dist_alerts_by_drivers_count(dist_zarr_uri: str, dist_version: str, overwrite=False):
@@ -22,20 +23,20 @@ def dist_alerts_by_drivers_count(dist_zarr_uri: str, dist_version: str, overwrit
         [1, 2, 3],  # confidence values
     )
     contextual_uri = f"s3://{DATA_LAKE_BUCKET}/umd_glad_dist_alerts_driver/zarr/umd_dist_alerts_drivers.zarr"
-    datasets = dist_common_tasks.load_data.with_options(
+    datasets = common_tasks.load_data.with_options(
         name="dist-alerts-by-natural-lands-load-data"
     )(dist_zarr_uri, contextual_uri=contextual_uri)
     compute_input = dist_common_tasks.setup_compute.with_options(
         name="set-up-dist-alerts-by-drivers-compute"
     )(datasets, expected_groups, contextual_name="driver")
 
-    result_dataset = dist_common_tasks.compute_zonal_stat.with_options(
+    result_dataset = common_tasks.compute_zonal_stat.with_options(
         name="dist-alerts-by-drivers-compute-zonal-stats"
     )(*compute_input, funcname="count")
-    result_df = dist_common_tasks.postprocess_result.with_options(
+    result_df = common_tasks.postprocess_result.with_options(
         name="dist-alerts-by-drivers-postprocess-result"
     )(result_dataset)
-    dist_common_tasks.save_result.with_options(
+    common_tasks.save_result.with_options(
         name="dist-alerts-by-drivers-save-result"
     )(result_df, result_uri)
 

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_drivers.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_drivers.py
@@ -31,7 +31,7 @@ def dist_alerts_by_drivers_count(dist_zarr_uri: str, dist_version: str, overwrit
 
     result_dataset = dist_common_tasks.compute_zonal_stat.with_options(
         name="dist-alerts-by-drivers-compute-zonal-stats"
-    )(*compute_input)
+    )(*compute_input, funcname="count")
     result_df = dist_common_tasks.postprocess_result.with_options(
         name="dist-alerts-by-drivers-postprocess-result"
     )(result_dataset)

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_natural_lands.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_natural_lands.py
@@ -5,6 +5,7 @@ from prefect import flow
 from pipelines.disturbance.prefect_flows import dist_common_tasks
 from pipelines.globals import DATA_LAKE_BUCKET
 from pipelines.utils import s3_uri_exists
+from pipelines.prefect_flows import common_tasks
 
 @flow(name="DIST alerts count by natural lands")
 def dist_alerts_by_natural_lands_count(dist_zarr_uri: str, dist_version: str, overwrite=False):
@@ -22,20 +23,20 @@ def dist_alerts_by_natural_lands_count(dist_zarr_uri: str, dist_version: str, ov
         [1, 2, 3],  # confidence values
     )
     contextual_uri = f"s3://{DATA_LAKE_BUCKET}/sbtn_natural_lands/zarr/sbtn_natural_lands_all_classes.zarr"
-    datasets = dist_common_tasks.load_data.with_options(
+    datasets = common_tasks.load_data.with_options(
         name="dist-alerts-by-natural-lands-load-data"
     )(dist_zarr_uri, contextual_uri=contextual_uri)
     compute_input = dist_common_tasks.setup_compute.with_options(
         name="set-up-dist-alerts-by-natural-lands-compute"
     )(datasets, expected_groups, contextual_name="natural_lands")
 
-    result_dataset = dist_common_tasks.compute_zonal_stat.with_options(
+    result_dataset = common_tasks.compute_zonal_stat.with_options(
         name="dist-alerts-by-natural-lands-compute-zonal-stats"
     )(*compute_input, funcname="count")
-    result_df = dist_common_tasks.postprocess_result.with_options(
+    result_df = common_tasks.postprocess_result.with_options(
         name="dist-alerts-by-natural-lands-postprocess-result"
     )(result_dataset)
-    result_uri = dist_common_tasks.save_result.with_options(
+    result_uri = common_tasks.save_result.with_options(
         name="dist-alerts-by-natural-lands-save-result"
     )(result_df, result_uri)
 

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_natural_lands.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_natural_lands.py
@@ -31,7 +31,7 @@ def dist_alerts_by_natural_lands_count(dist_zarr_uri: str, dist_version: str, ov
 
     result_dataset = dist_common_tasks.compute_zonal_stat.with_options(
         name="dist-alerts-by-natural-lands-compute-zonal-stats"
-    )(*compute_input)
+    )(*compute_input, funcname="count")
     result_df = dist_common_tasks.postprocess_result.with_options(
         name="dist-alerts-by-natural-lands-postprocess-result"
     )(result_dataset)

--- a/pipelines/disturbance/stages.py
+++ b/pipelines/disturbance/stages.py
@@ -1,52 +1,7 @@
-from typing import Callable, Tuple, Optional
-import pandas as pd
+from typing import Tuple, Optional
 import xarray as xr
-from flox import ReindexArrayType, ReindexStrategy
-from flox.xarray import xarray_reduce
 
-from pipelines.globals import (
-    country_zarr_uri,
-    region_zarr_uri,
-    subregion_zarr_uri,
-)
-
-
-LoaderType = Callable[[str, Optional[str]], Tuple[xr.Dataset, ...]]
 ExpectedGroupsType = Tuple
-SaverType = Callable[[pd.DataFrame, str], None]
-
-
-def load_data(
-    dist_zarr_uri: str,
-    contextual_uri: Optional[str] = None,
-) -> Tuple[xr.Dataset, ...]:
-    """Load in the Dist alert Zarr, the GADM zarrs, and possibly a contextual layer zarr"""
-
-    dist_alerts = _load_zarr(dist_zarr_uri)
-
-    country = _load_zarr(country_zarr_uri)
-    country_aligned = xr.align(dist_alerts, country, join="left")[1]
-    region = _load_zarr(region_zarr_uri)
-    region_aligned = xr.align(dist_alerts, region, join="left")[1]
-    subregion = _load_zarr(subregion_zarr_uri)
-    subregion_aligned = xr.align(dist_alerts, subregion, join="left")[1]
-
-    if contextual_uri is not None:
-        contextual_layer = _load_zarr(contextual_uri)
-        contextual_layer_aligned = xr.align(dist_alerts, contextual_layer, join="left")[
-            1
-        ]
-    else:
-        contextual_layer_aligned = None
-
-    return (
-        dist_alerts,
-        country_aligned,
-        region_aligned,
-        subregion_aligned,
-        contextual_layer_aligned,
-    )
-
 
 def setup_compute(
     datasets: Tuple[xr.Dataset, ...],
@@ -66,59 +21,11 @@ def setup_compute(
     )
     if contextual_layer is not None:
         groupbys = (
-            groupbys[:2]
+            groupbys[:3]
             + (contextual_layer.band_data.rename(contextual_column_name),)
-            + groupbys[2:]
+            + groupbys[3:]
         )
 
     return (mask, groupbys, expected_groups)
 
 
-def compute(reduce_mask: xr.DataArray, reduce_groupbys: Tuple, expected_groups: Tuple, funcname: str):
-    print("Starting reduce")
-    alerts_count = xarray_reduce(
-        reduce_mask,
-        *reduce_groupbys,
-        func=funcname,
-        expected_groups=expected_groups,
-        reindex=ReindexStrategy(
-            blockwise=False, array_type=ReindexArrayType.SPARSE_COO
-        ),
-        fill_value=0,
-    ).compute()
-    print("Finished reduce")
-    return alerts_count
-
-
-def create_result_dataframe(alerts_count: xr.Dataset) -> pd.DataFrame:
-    sparse_data = alerts_count.data
-    dim_names = alerts_count.dims
-    indices = sparse_data.coords
-    values = sparse_data.data
-
-    coord_dict = {
-        dim: alerts_count.coords[dim].values[idx]
-        for dim, idx in zip(dim_names, indices)
-    }
-    coord_dict["value"] = values
-
-    return pd.DataFrame(coord_dict)
-
-
-def save_results(
-    df: pd.DataFrame, results_uri: str
-) -> str:
-    print("Starting parquet")
-
-    _save_parquet(df, results_uri)
-    print("Finished parquet")
-    return results_uri
-
-
-# _load_zarr and _save_parquet are the functions being mocked by the unit tests.
-def _save_parquet(df: pd.DataFrame, results_uri: str) -> None:
-    df.to_parquet(results_uri, index=False)
-
-
-def _load_zarr(zarr_uri):
-    return xr.open_zarr(zarr_uri)

--- a/pipelines/disturbance/stages.py
+++ b/pipelines/disturbance/stages.py
@@ -74,12 +74,12 @@ def setup_compute(
     return (mask, groupbys, expected_groups)
 
 
-def compute(reduce_mask: xr.DataArray, reduce_groupbys: Tuple, expected_groups: Tuple):
+def compute(reduce_mask: xr.DataArray, reduce_groupbys: Tuple, expected_groups: Tuple, funcname: str):
     print("Starting reduce")
     alerts_count = xarray_reduce(
         reduce_mask,
         *reduce_groupbys,
-        func="count",
+        func=funcname,
         expected_groups=expected_groups,
         reindex=ReindexStrategy(
             blockwise=False, array_type=ReindexArrayType.SPARSE_COO

--- a/pipelines/natural_lands/nl_flow.py
+++ b/pipelines/natural_lands/nl_flow.py
@@ -1,0 +1,51 @@
+import logging
+
+import numpy as np
+from prefect import flow
+
+from pipelines.globals import DATA_LAKE_BUCKET
+from pipelines.utils import s3_uri_exists
+from pipelines.disturbance.prefect_flows import dist_common_tasks
+from pipelines.natural_lands.prefect_flows import nl_tasks
+
+
+@flow(name="Natural lands area")
+def gadm_natural_lands_area(
+    overwrite: bool = False
+):
+    logging.getLogger("distributed.client").setLevel(logging.ERROR)  # or logging.ERROR
+
+    base_uri = "s3://gfw-data-lake/umd_area_2013/v1.10/raster/epsg-4326/zarr/pixel_area.zarr"
+    contextual_uri = "s3://gfw-data-lake/sbtn_natural_lands/zarr/sbtn_natural_lands_all_classes.zarr"
+    contextual_column_name = "natural_lands"
+    result_uri = f's3://{DATA_LAKE_BUCKET}/sbtn_natural_lands/zarr/area_by_natural_lands_all_adm2_raw.parquet'
+    funcname = "sum"
+
+    if not overwrite and s3_uri_exists(result_uri):
+        return result_uri
+
+    expected_groups = (
+        np.arange(894),     # country iso codes
+        np.arange(1, 86),   # region codes
+        np.arange(1, 854),  # subregion codes
+        np.arange(1, 22),   # natural lands categories
+    )
+
+    datasets = dist_common_tasks.load_data.with_options(
+        name="area-by-natural-lands-load-data"
+    )(base_uri, contextual_uri=contextual_uri)
+
+    compute_input = nl_tasks.setup_compute.with_options(
+        name="set-up-area-by-natural-lands-compute"
+    )(datasets, expected_groups, contextual_name=contextual_column_name)
+
+    result_dataset = dist_common_tasks.compute_zonal_stat.with_options(
+        name="area-by-natural-lands-compute-zonal-stats"
+    )(*compute_input, funcname=funcname)
+    result_df = dist_common_tasks.postprocess_result.with_options(
+        name="area-by-natural-lands-postprocess-result"
+    )(result_dataset)
+    result_uri = dist_common_tasks.save_result.with_options(
+        name="area-by-natural-lands-save-result"
+    )(result_df, result_uri)
+    return result_uri

--- a/pipelines/natural_lands/prefect_flows/nl_flow.py
+++ b/pipelines/natural_lands/prefect_flows/nl_flow.py
@@ -7,6 +7,7 @@ from pipelines.globals import DATA_LAKE_BUCKET
 from pipelines.utils import s3_uri_exists
 from pipelines.disturbance.prefect_flows import dist_common_tasks
 from pipelines.natural_lands.prefect_flows import nl_tasks
+from pipelines.prefect_flows import common_tasks
 
 
 @flow(name="Natural lands area")
@@ -18,7 +19,7 @@ def gadm_natural_lands_area(
     base_uri = "s3://gfw-data-lake/umd_area_2013/v1.10/raster/epsg-4326/zarr/pixel_area.zarr"
     contextual_uri = "s3://gfw-data-lake/sbtn_natural_lands/zarr/sbtn_natural_lands_all_classes.zarr"
     contextual_column_name = "natural_lands"
-    result_uri = f's3://{DATA_LAKE_BUCKET}/sbtn_natural_lands/zarr/area_by_natural_lands_all_adm2_raw.parquet'
+    result_uri = f's3://{DATA_LAKE_BUCKET}/sbtn_natural_lands/tabular/zonal_stats/gadm/gadm_adm2.parquet'
     funcname = "sum"
 
     if not overwrite and s3_uri_exists(result_uri):
@@ -31,7 +32,7 @@ def gadm_natural_lands_area(
         np.arange(1, 22),   # natural lands categories
     )
 
-    datasets = dist_common_tasks.load_data.with_options(
+    datasets = common_tasks.load_data.with_options(
         name="area-by-natural-lands-load-data"
     )(base_uri, contextual_uri=contextual_uri)
 
@@ -39,13 +40,13 @@ def gadm_natural_lands_area(
         name="set-up-area-by-natural-lands-compute"
     )(datasets, expected_groups, contextual_name=contextual_column_name)
 
-    result_dataset = dist_common_tasks.compute_zonal_stat.with_options(
+    result_dataset = common_tasks.compute_zonal_stat.with_options(
         name="area-by-natural-lands-compute-zonal-stats"
     )(*compute_input, funcname=funcname)
-    result_df = dist_common_tasks.postprocess_result.with_options(
+    result_df = common_tasks.postprocess_result.with_options(
         name="area-by-natural-lands-postprocess-result"
     )(result_dataset)
-    result_uri = dist_common_tasks.save_result.with_options(
+    result_uri = common_tasks.save_result.with_options(
         name="area-by-natural-lands-save-result"
     )(result_df, result_uri)
     return result_uri

--- a/pipelines/natural_lands/prefect_flows/nl_tasks.py
+++ b/pipelines/natural_lands/prefect_flows/nl_tasks.py
@@ -1,0 +1,13 @@
+from typing import Optional, Tuple
+import xarray as xr
+
+from prefect import task
+from pipelines.natural_lands import stages
+
+@task
+def setup_compute(
+    datasets: Tuple[xr.Dataset, ...],
+    expected_groups,
+    contextual_name: Optional[str] = None,
+) -> Tuple:
+    return stages.setup_compute(datasets, expected_groups, contextual_name)

--- a/pipelines/natural_lands/stages.py
+++ b/pipelines/natural_lands/stages.py
@@ -1,0 +1,28 @@
+from typing import Callable, Optional, Tuple
+import pandas as pd
+import xarray as xr
+
+LoaderType = Callable[[str, Optional[str]], Tuple[xr.Dataset, ...]]
+ExpectedGroupsType = Tuple
+SaverType = Callable[[pd.DataFrame, str], None]
+
+def setup_compute(
+    datasets: Tuple[xr.Dataset, ...],
+    expected_groups: Optional[ExpectedGroupsType],
+    contextual_column_name: Optional[str] = None,
+) -> Tuple:
+    """Setup the arguments for the xrarray reduce on natural lands by area"""
+    base_zarr, country, region, subregion, contextual_layer = datasets
+
+    mask = base_zarr.band_data
+    groupbys: Tuple[xr.Dataset, ...] = (
+        country.band_data.rename("country"),
+        region.band_data.rename("region"),
+        subregion.band_data.rename("subregion"),
+    )
+    if contextual_layer is not None:
+        groupbys = (
+            groupbys + (contextual_layer.band_data.rename(contextual_column_name),)
+        )
+
+    return (mask, groupbys, expected_groups)

--- a/pipelines/prefect_flows/common_stages.py
+++ b/pipelines/prefect_flows/common_stages.py
@@ -1,0 +1,92 @@
+from typing import Callable, Tuple, Optional
+import pandas as pd
+import xarray as xr
+from flox import ReindexArrayType, ReindexStrategy
+from flox.xarray import xarray_reduce
+
+from pipelines.globals import (
+    country_zarr_uri,
+    region_zarr_uri,
+    subregion_zarr_uri,
+)
+
+
+def load_data(
+    dist_zarr_uri: str,
+    contextual_uri: Optional[str] = None,
+) -> Tuple[xr.Dataset, ...]:
+    """Load in the Dist alert Zarr, the GADM zarrs, and possibly a contextual layer zarr"""
+
+    dist_alerts = _load_zarr(dist_zarr_uri)
+
+    country = _load_zarr(country_zarr_uri)
+    country_aligned = xr.align(dist_alerts, country, join="left")[1]
+    region = _load_zarr(region_zarr_uri)
+    region_aligned = xr.align(dist_alerts, region, join="left")[1]
+    subregion = _load_zarr(subregion_zarr_uri)
+    subregion_aligned = xr.align(dist_alerts, subregion, join="left")[1]
+
+    if contextual_uri is not None:
+        contextual_layer = _load_zarr(contextual_uri)
+        contextual_layer_aligned = xr.align(dist_alerts, contextual_layer, join="left")[
+            1
+        ]
+    else:
+        contextual_layer_aligned = None
+
+    return (
+        dist_alerts,
+        country_aligned,
+        region_aligned,
+        subregion_aligned,
+        contextual_layer_aligned,
+    )
+
+def compute(reduce_mask: xr.DataArray, reduce_groupbys: Tuple, expected_groups: Tuple, funcname: str):
+    print("Starting reduce")
+    alerts_count = xarray_reduce(
+        reduce_mask,
+        *reduce_groupbys,
+        func=funcname,
+        expected_groups=expected_groups,
+        reindex=ReindexStrategy(
+            blockwise=False, array_type=ReindexArrayType.SPARSE_COO
+        ),
+        fill_value=0,
+    ).compute()
+    print("Finished reduce")
+    return alerts_count
+
+
+def create_result_dataframe(alerts_count: xr.Dataset) -> pd.DataFrame:
+    sparse_data = alerts_count.data
+    dim_names = alerts_count.dims
+    indices = sparse_data.coords
+    values = sparse_data.data
+
+    coord_dict = {
+        dim: alerts_count.coords[dim].values[idx]
+        for dim, idx in zip(dim_names, indices)
+    }
+    coord_dict["value"] = values
+
+    return pd.DataFrame(coord_dict)
+
+
+def save_results(
+    df: pd.DataFrame, results_uri: str
+) -> str:
+    print("Starting parquet")
+
+    _save_parquet(df, results_uri)
+    print("Finished parquet")
+    return results_uri
+
+
+# _load_zarr and _save_parquet are the functions being mocked by the unit tests.
+def _save_parquet(df: pd.DataFrame, results_uri: str) -> None:
+    df.to_parquet(results_uri, index=False)
+
+
+def _load_zarr(zarr_uri):
+    return xr.open_zarr(zarr_uri)

--- a/pipelines/prefect_flows/common_tasks.py
+++ b/pipelines/prefect_flows/common_tasks.py
@@ -1,0 +1,28 @@
+from typing import Optional, Tuple
+import xarray as xr
+import pandas as pd
+
+from prefect import task
+
+from pipelines.prefect_flows import common_stages
+
+@task
+def load_data(dist_zarr_uri: str, contextual_uri: Optional[str] = None):
+    return common_stages.load_data(dist_zarr_uri, contextual_uri)
+
+
+@task
+def compute_zonal_stat(dataset: xr.DataArray, groupbys: Tuple, expected_groups: Tuple, funcname: str):
+    '''Do the reduction with the specified groupbys. funcname is the name of the
+    reduction function'''
+    return common_stages.compute(dataset, groupbys, expected_groups, funcname)
+
+
+@task
+def postprocess_result(result: xr.Dataset):
+    return common_stages.create_result_dataframe(result)
+
+
+@task
+def save_result(result_df: pd.DataFrame, result_uri: str) -> str:
+    return common_stages.save_results(result_df, result_uri)

--- a/pipelines/utils.py
+++ b/pipelines/utils.py
@@ -20,4 +20,3 @@ def s3_uri_exists(s3_uri):
             return False
         else:
             raise
-        

--- a/test/pipelines/disturbance/test_gadm_dist_alerts.py
+++ b/test/pipelines/disturbance/test_gadm_dist_alerts.py
@@ -10,8 +10,8 @@ from pipelines.disturbance.prefect_flows import dist_alerts_count
 
 @pytest.mark.slow
 @pytest.mark.integration
-@patch("pipelines.disturbance.stages._save_parquet")
-@patch("pipelines.disturbance.stages._load_zarr")
+@patch("pipelines.prefect_flows.common_stages._save_parquet")
+@patch("pipelines.prefect_flows.common_stages._load_zarr")
 def test_gadm_dist_alerts_happy_path(
     mock_load_zarr, mock_save_parquet, dist_ds, country_ds, region_ds, subregion_ds
 ):
@@ -34,8 +34,8 @@ def test_gadm_dist_alerts_happy_path(
 
 @pytest.mark.slow
 @pytest.mark.integration
-@patch("pipelines.disturbance.stages._save_parquet")
-@patch("pipelines.disturbance.stages._load_zarr")
+@patch("pipelines.prefect_flows.common_stages._save_parquet")
+@patch("pipelines.prefect_flows.common_stages._load_zarr")
 def test_gadm_dist_alerts_result(
     mock_load_zarr, mock_save_parquet, dist_ds, country_ds, region_ds, subregion_ds
 ):

--- a/test/pipelines/disturbance/test_gadm_dist_alerts_by_driver.py
+++ b/test/pipelines/disturbance/test_gadm_dist_alerts_by_driver.py
@@ -9,8 +9,8 @@ from pipelines.disturbance.prefect_flows import dist_alerts_by_drivers_count
 
 @pytest.mark.integration
 @pytest.mark.slow
-@patch("pipelines.disturbance.stages._save_parquet")
-@patch("pipelines.disturbance.stages._load_zarr")
+@patch("pipelines.prefect_flows.common_stages._save_parquet")
+@patch("pipelines.prefect_flows.common_stages._load_zarr")
 def test_gadm_dist_alerts_by_driver_happy_path(
     mock_load_zarr,
     mock_save_parquet,
@@ -44,8 +44,8 @@ def test_gadm_dist_alerts_by_driver_happy_path(
 
 @pytest.mark.slow
 @pytest.mark.integration
-@patch("pipelines.disturbance.stages._save_parquet")
-@patch("pipelines.disturbance.stages._load_zarr")
+@patch("pipelines.prefect_flows.common_stages._save_parquet")
+@patch("pipelines.prefect_flows.common_stages._load_zarr")
 def test_gadm_dist_alerts_by_driver_result(
     mock_load_zarr,
     mock_save_parquet,

--- a/test/pipelines/disturbance/test_gadm_dist_alerts_by_natural_lands.py
+++ b/test/pipelines/disturbance/test_gadm_dist_alerts_by_natural_lands.py
@@ -9,8 +9,8 @@ from pipelines.disturbance.prefect_flows import dist_alerts_by_natural_lands_cou
 
 @pytest.mark.integration
 @pytest.mark.slow
-@patch("pipelines.disturbance.stages._save_parquet")
-@patch("pipelines.disturbance.stages._load_zarr")
+@patch("pipelines.prefect_flows.common_stages._save_parquet")
+@patch("pipelines.prefect_flows.common_stages._load_zarr")
 def test_gadm_dist_alerts_happy_path(
     mock_load_zarr,
     mock_save_parquet,
@@ -44,8 +44,8 @@ def test_gadm_dist_alerts_happy_path(
 
 @pytest.mark.integration
 @pytest.mark.slow
-@patch("pipelines.disturbance.stages._save_parquet")
-@patch("pipelines.disturbance.stages._load_zarr")
+@patch("pipelines.prefect_flows.common_stages._save_parquet")
+@patch("pipelines.prefect_flows.common_stages._load_zarr")
 def test_gadm_dist_alerts_result(
     mock_load_zarr,
     mock_save_parquet,

--- a/test/pipelines/natural_lands/conftest.py
+++ b/test/pipelines/natural_lands/conftest.py
@@ -1,0 +1,83 @@
+import pytest
+import numpy as np
+import xarray as xr
+import dask.array as da
+
+@pytest.fixture
+def expected_groups():
+    return (
+        # Match expected groups to minimal data values
+        [12],  # Country values in minimal data
+        [7],  # Region values
+        [124, 125],  # Subregion values
+        [2, 2],  # Natural land values
+    )
+
+
+@pytest.fixture
+def country_ds():
+    country = xr.Dataset(
+        data_vars={
+            "band_data": (
+                ("band", "y", "x"),
+                da.array([[[12, 12], [12, 12]]], dtype=np.uint16),
+            )
+        }
+    )
+
+    return country
+
+
+@pytest.fixture
+def region_ds():
+    region = xr.Dataset(
+        data_vars={
+            "band_data": (
+                ("band", "y", "x"),
+                da.array([[[7, 7], [7, 7]]], dtype=np.uint16),
+            )
+        }
+    )
+    return region
+
+
+@pytest.fixture
+def subregion_ds():
+    subregion = xr.Dataset(
+        data_vars={
+            "band_data": (
+                ("band", "y", "x"),
+                da.array([[[124, 124], [124, 125]]], dtype=np.uint16),
+            )
+        }
+    )
+
+    return subregion
+
+
+@pytest.fixture
+def natural_lands_ds():
+    natural_lands = xr.Dataset(
+        data_vars={
+            "band_data": (
+                ("band", "y", "x"),
+                da.array([[[2, 2], [2, 2]]], dtype=np.uint8),
+            )
+        },
+    )
+
+    return natural_lands
+
+
+@pytest.fixture
+def area_ds():
+    drivers = xr.Dataset(
+        data_vars={
+            "band_data": (
+                ("band", "y", "x"),
+                da.array([[[760.0, 760.0], [760.0, 760.0]]], dtype=np.float32),
+            )
+        },
+    )
+
+    return drivers

--- a/test/pipelines/natural_lands/test_gadm_area_by_natural_lands.py
+++ b/test/pipelines/natural_lands/test_gadm_area_by_natural_lands.py
@@ -4,13 +4,13 @@ from unittest.mock import patch
 from pandera.pandas import DataFrameSchema, Column, Check, dtypes
 from prefect.testing.utilities import prefect_test_harness
 
-from pipelines.natural_lands.nl_flow import gadm_natural_lands_area
+from pipelines.natural_lands.prefect_flows.nl_flow import gadm_natural_lands_area
 
 
 @pytest.mark.integration
 @pytest.mark.slow
-@patch("pipelines.disturbance.stages._save_parquet")
-@patch("pipelines.disturbance.stages._load_zarr")
+@patch("pipelines.prefect_flows.common_stages._save_parquet")
+@patch("pipelines.prefect_flows.common_stages._load_zarr")
 def test_gadm_area_by_natural_lands_result(
     mock_load_zarr,
     mock_save_parquet,
@@ -64,7 +64,7 @@ def test_gadm_area_by_natural_lands_result(
 
     assert (
         result_uri
-        == "s3://gfw-data-lake/sbtn_natural_lands/zarr/area_by_natural_lands_all_adm2_raw.parquet"
+        == "s3://gfw-data-lake/sbtn_natural_lands/tabular/zonal_stats/gadm/gadm_adm2.parquet"
     )
 
     # Verify

--- a/test/pipelines/natural_lands/test_gadm_area_by_natural_lands.py
+++ b/test/pipelines/natural_lands/test_gadm_area_by_natural_lands.py
@@ -1,0 +1,73 @@
+import pytest
+from unittest.mock import patch
+
+from pandera.pandas import DataFrameSchema, Column, Check, dtypes
+from prefect.testing.utilities import prefect_test_harness
+
+from pipelines.natural_lands.nl_flow import gadm_natural_lands_area
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@patch("pipelines.disturbance.stages._save_parquet")
+@patch("pipelines.disturbance.stages._load_zarr")
+def test_gadm_area_by_natural_lands_result(
+    mock_load_zarr,
+    mock_save_parquet,
+    area_ds,
+    country_ds,
+    region_ds,
+    subregion_ds,
+    natural_lands_ds,
+):
+    alert_schema = DataFrameSchema(
+        name="GADM Dist Alerts",
+        columns={
+            "country": Column(int, Check.ge(0)),
+            "region": Column(int, Check.ge(0)),
+            "subregion": Column(int, Check.ge(0)),
+            "natural_lands": Column(int, Check.ge(0)),
+            "value": Column(dtypes.Float32, Check.in_range(0.0, 2300.0)),
+        },
+        unique=[
+            "country",
+            "region",
+            "subregion",
+            "natural_lands",
+        ],
+        checks=Check(
+            lambda df: (
+                df.groupby(
+                    ["country", "region", "subregion", "natural_lands"]
+                )["value"].transform("nunique")
+                == 1
+            ),
+            name="two_confidences_per_group",
+            error="Each location-date must have exactly 1 confidence levels",
+        ),
+    )
+
+    mock_load_zarr.side_effect = [
+        area_ds,
+        country_ds,
+        region_ds,
+        subregion_ds,
+        natural_lands_ds,
+    ]
+
+    with prefect_test_harness():
+        result_uri = gadm_natural_lands_area(
+            #  dist_zarr_uri="s3://dummy_zarr_uri",
+            #  dist_version="test_v1",
+            overwrite=True
+        )
+
+    assert (
+        result_uri
+        == "s3://gfw-data-lake/sbtn_natural_lands/zarr/area_by_natural_lands_all_adm2_raw.parquet"
+    )
+
+    # Verify
+    result = mock_save_parquet.call_args[0][0]
+    print(f"\nGADM dist alerts by natural lands result:\n{result}")
+    alert_schema.validate(result)


### PR DESCRIPTION
PZB-295 (under PZB-252) Added natural lands flow.

Create natural lands flow which does one analysis, which is area of natural lands, grouped by gadm areas.

Created a separate pipeline directory 'pipelines/natural_lands', and similarly new test directory 'test/pipelines/natural_lands'.

Tested actual prefect runs to create the parquet file, and local tests run.
