### PR TITLE
PZB-148 Analysis/pipeline for dist by land_cover

### DIFF
--- a/api/app/analysis/dist_alerts/analysis.py
+++ b/api/app/analysis/dist_alerts/analysis.py
@@ -53,6 +53,18 @@ DIST_DRIVERS = {
     5: "Unclassified",
 }
 
+LAND_COVER_MAPPING = {
+    0: "Bare and sparse vegetation",
+    1: "Short vegetation",
+    2: "Tree cover",
+    3: "Wetland – short vegetation",
+    4: "Water",
+    5: "Snow/ice",
+    6: "Cropland",
+    7: "Built-up",
+    8: "Cultivated grasslands",
+}
+
 
 async def zonal_statistics_on_aois(aois, dask_client, intersection=None):
     geojsons = await get_geojson(aois)
@@ -118,6 +130,18 @@ async def zonal_statistics(aoi, geojson, intersection: Optional[str]=None) -> Da
 
         groupby_layers.append(grasslands_only)
         expected_groups.append([0, 1])
+    elif intersection == "land_cover":
+        land_cover = read_zarr_clipped_to_geojson(
+            "s3://gfw-data-lake/umd_lcl_land_cover/v2/raster/epsg-4326/zarr/umd_lcl_land_cover_2015-2024.zarr",
+            geojson,
+        ).band_data.reindex_like(dist_alerts, method="nearest", tolerance=1e-5)
+
+        # Only use a single year of land_cover when used as a contextual layer.
+        land_cover_year2024 = land_cover.sel(year=2024)
+        land_cover_year2024.name = "land_cover_class"
+
+        groupby_layers.append(land_cover_year2024)
+        expected_groups.append(np.arange(8))
 
     alerts_count: xr.DataArray = xarray_reduce(
         dist_alerts.alert_date,
@@ -157,13 +181,18 @@ async def zonal_statistics(aoi, geojson, intersection: Optional[str]=None) -> Da
             (lambda x: "grasslands" if x == 1 else "non-grasslands"), meta=("grasslands", "uint8")
         )
         alerts_df = alerts_df.drop("year", axis=1).reset_index(drop=True)
+    elif intersection == "land_cover":
+        alerts_df["land_cover_class"] = alerts_df["land_cover_class"].apply(
+            (lambda x: LAND_COVER_MAPPING.get(x, "Unclassified"))
+        )
+        alerts_df = alerts_df.drop("year", axis=1).reset_index(drop=True)
 
     alerts_df = alerts_df[alerts_df.value > 0]
     return alerts_df
 
 
 async def get_precomputed_statistics(aoi, intersection: Optional[str], dask_client):
-    if aoi["type"] != "admin" or intersection not in [None, "natural_lands", "driver", "grasslands"]:
+    if aoi["type"] != "admin" or intersection not in [None, "natural_lands", "driver", "grasslands", "land_cover"]:
         raise ValueError(
             f"No precomputed statistics available for AOI type {aoi['type']} and intersection {intersection}"
         )
@@ -216,6 +245,8 @@ def get_precomputed_table(aoi_type: str, intersection: Optional[str]) -> str:
             table = "gadm_dist_alerts_by_natural_lands"
         elif intersection == "grasslands":
             table = "gadm_dist_alerts_by_grasslands"
+        elif intersection == "land_cover":
+            table = "gadm_dist_alerts_by_land_cover"
         else:
             raise ValueError(f"No way to calculate intersection {intersection}")
     else:

--- a/api/app/analysis/dist_alerts/query.py
+++ b/api/app/analysis/dist_alerts/query.py
@@ -17,6 +17,8 @@ def create_gadm_dist_query(
             intersection_col = "natural_land_class"
         elif intersection == "grasslands":
             intersection_col = "grasslands"
+        elif intersection == "land_cover":
+            intersection_col = "land_cover"
 
     from_clause = f"FROM '/tmp/{table}.parquet'"
     select_clause = "SELECT country"
@@ -45,7 +47,12 @@ def create_gadm_dist_query(
     order_by_clause = f"ORDER {by_clause}"
 
     # Query and make sure output names match the expected schema (?)
-    select_clause += ", STRFTIME(alert_date, '%Y-%m-%d') AS alert_date, alert_confidence AS confidence, SUM(count)::INT AS value"
+    select_clause += ", STRFTIME(alert_date, '%Y-%m-%d') AS alert_date, alert_confidence AS confidence, "
+    # This is temporary - we will convert all queries to area__ha soon.
+    if intersection == "land_cover":
+        select_clause += "SUM(area__ha)::FLOAT AS value"
+    else:
+        select_clause += "SUM(count)::INT AS value"
     query = f"{select_clause} {from_clause} {where_clause} {group_by_clause} {order_by_clause}"
 
     return query

--- a/api/app/models/land_change/dist_alerts.py
+++ b/api/app/models/land_change/dist_alerts.py
@@ -41,7 +41,7 @@ class DistAlertsAnalyticsIn(StrictBaseModel):
         pattern=DATE_REGEX,
         examples=["2023", "2023-12-31"],
     )
-    intersections: List[Literal["driver", "natural_lands", "grasslands"]] = Field(
+    intersections: List[Literal["driver", "natural_lands", "grasslands", "land_cover"]] = Field(
         ..., min_length=0, max_length=1, description="List of intersection types"
     )
 

--- a/api/test/integration/analysis/dist_alerts/test_analysis.py
+++ b/api/test/integration/analysis/dist_alerts/test_analysis.py
@@ -4,7 +4,6 @@ from app.analysis.dist_alerts.analysis import zonal_statistics
 from app.models.land_change.dist_alerts import DistAlertsAnalytics
 
 import asyncio
-import numpy as np
 import pandas as pd
 from dask.dataframe import DataFrame as DaskDataFrame
 
@@ -12,7 +11,7 @@ from dask.dataframe import DataFrame as DaskDataFrame
 class TestDistAlertsZonalStats:
 
     @pytest.mark.asyncio
-    async def test_zonal_statistics_drivers_happy_path(self):
+    async def test_zonal_statistics_drivers_happy_path(self) -> None:
         geojson = {
             "type": "Polygon",
             "coordinates": [
@@ -26,13 +25,11 @@ class TestDistAlertsZonalStats:
             ],
         }
 
-        _: DistAlertsAnalytics = await zonal_statistics(
+        _: DaskDataFrame = await zonal_statistics(
             aoi={"type": "indigenous_land", "id": "1918"},
             geojson=geojson,
             intersection="driver",
         )
-
-
 
     @pytest.mark.asyncio
     async def test_zonal_statistics_grasslands_happy_path(
@@ -70,6 +67,45 @@ class TestDistAlertsZonalStats:
                 "value": [6, 1, 198, 28, 3, 3, 4, 1, 6, 1, 3, 1, 1, 1],
                 "aoi_type": ["feature", "feature", "feature", "feature", "feature", "feature", "feature", "feature", "feature", "feature", "feature", "feature", "feature", "feature", ],
                 "aoi_id": ["test_aoi", "test_aoi", "test_aoi", "test_aoi", "test_aoi", "test_aoi", "test_aoi", "test_aoi", "test_aoi", "test_aoi", "test_aoi", "test_aoi", "test_aoi", "test_aoi", ],
+            }
+        )
+        print(computed_df)
+        pd.testing.assert_frame_equal(expected_df, computed_df, check_like=True)
+
+    @pytest.mark.asyncio
+    async def test_zonal_statistics_land_cover_happy_path(
+            self
+    ) -> None:
+        geojson = {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [34.92, -2.997],
+                    [34.93, -2.997],
+                    [34.93, -3.0],
+                    [34.92, -3.0],
+                    [34.92, -2.997]
+                ]
+            ],
+        }
+
+        aoi = {
+            "type": "Feature",
+            "properties": {"id": "test_aoi"},
+            "geometry": geojson,
+        }
+        result_df: DaskDataFrame = await zonal_statistics(aoi, aoi["geometry"], intersection="land_cover")
+
+        loop = asyncio.get_event_loop()
+        computed_df = await loop.run_in_executor(None, result_df.compute)
+        expected_df = pd.DataFrame(
+            {
+                "alert_date": ["2024-08-13", "2024-08-13", "2024-08-13", "2024-08-13", "2024-08-16", "2025-01-23", "2025-01-23", "2025-01-23", "2025-02-19", "2025-03-04"],
+                "confidence": ["high", "high", "high", "high", "high", "low", "high", "high", "high", "low", ],
+                "land_cover_class": ["Short vegetation", "Tree cover", "Wetland – short vegetation", "Cropland", "Short vegetation", "Cropland", "Short vegetation", "Cropland", "Tree cover", "Short vegetation"],
+                "value": [43, 5, 3, 82, 3, 1, 3, 3, 1, 1],
+                "aoi_type": ["feature", "feature", "feature", "feature", "feature", "feature", "feature", "feature", "feature", "feature", ],
+                "aoi_id": ["test_aoi", "test_aoi", "test_aoi", "test_aoi", "test_aoi", "test_aoi", "test_aoi", "test_aoi", "test_aoi", "test_aoi"],
             }
         )
         print(computed_df)

--- a/pipelines/dist_flow.py
+++ b/pipelines/dist_flow.py
@@ -93,6 +93,11 @@ def dist_alerts_flow(overwrite=False) -> list[str]:
         )
         result_uris.append(gadm_dist_by_grasslands_result)
 
+        gadm_dist_by_land_cover_result = prefect_flows.dist_alerts_by_land_cover_area(
+            dist_zarr_uri, dist_version, overwrite=overwrite
+        )
+        result_uris.append(gadm_dist_by_land_cover_result)
+
         validate_result = run_validation_suite(gadm_dist_result)
 
     except Exception:

--- a/pipelines/disturbance/prefect_flows/__init__.py
+++ b/pipelines/disturbance/prefect_flows/__init__.py
@@ -2,3 +2,4 @@ from .gadm_dist_alerts import dist_alerts_area
 from .gadm_dist_alerts_by_natural_lands import dist_alerts_by_natural_lands_area
 from .gadm_dist_alerts_by_drivers import dist_alerts_by_drivers_area
 from .gadm_dist_alerts_by_grasslands import dist_alerts_by_grasslands_area
+from .gadm_dist_alerts_by_land_cover import dist_alerts_by_land_cover_area

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_land_cover.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_land_cover.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pandas as pd
+
+from prefect import flow
+
+from pipelines.disturbance.prefect_flows import dist_common_tasks
+from pipelines.globals import DATA_LAKE_BUCKET
+from pipelines.utils import s3_uri_exists
+from pipelines.prefect_flows import common_tasks
+
+LAND_COVER_MAPPING = {
+    0: "Bare and sparse vegetation",
+    1: "Short vegetation",
+    2: "Tree cover",
+    3: "Wetland – short vegetation",
+    4: "Water",
+    5: "Snow/ice",
+    6: "Cropland",
+    7: "Built-up",
+    8: "Cultivated grasslands",
+}
+
+
+@flow(name="DIST alerts count by land cover")
+def dist_alerts_by_land_cover_area(dist_zarr_uri: str, dist_version: str, overwrite=False):
+    result_filename = "dist_alerts_by_land_cover"
+    result_uri = f"s3://{DATA_LAKE_BUCKET}/umd_glad_dist_alerts/{dist_version}/tabular/zonal_stats/gadm/gadm_adm2_{result_filename}.parquet"
+    if not overwrite and s3_uri_exists(result_uri):
+        return result_uri
+
+    expected_groups = (
+        np.arange(894),  # country ISO codes
+        np.arange(86),  # region codes
+        np.arange(854),  # subregion codes
+        np.arange(8),  # land cover classes
+        np.arange(731, 2000),  # dates values
+        [1, 2, 3],  # confidence values
+    )
+    contextual_uri = "s3://gfw-data-lake/umd_lcl_land_cover/v2/raster/epsg-4326/zarr/umd_lcl_land_cover_2015-2024.zarr"
+    datasets = dist_common_tasks.load_data.with_options(
+        name="dist-alerts-by-land-cover-load-data"
+    )(dist_zarr_uri, contextual_uri=contextual_uri)
+    # We only need year 2024 of the land cover contextual layer. We can fix later to
+    # put this in a land-cover-specific setup_compute() task.
+    datasets = datasets[:5] + (datasets[5].sel(year=2024), )
+    compute_input = dist_common_tasks.setup_compute.with_options(
+        name="set-up-dist-alerts-by-land-cover-compute"
+    )(datasets, expected_groups, contextual_name="land_cover")
+
+    result_dataset = common_tasks.compute_zonal_stat.with_options(
+        name="dist-alerts-by-land-cover-compute-zonal-stats"
+    )(*compute_input, funcname="sum")
+    result_df: pd.DataFrame = dist_common_tasks.postprocess_result.with_options(
+        name="dist-alerts-by-land-cover-postprocess-result"
+    )(result_dataset)
+
+    result_df["land_cover"] = result_df["land_cover"].apply(lambda x: LAND_COVER_MAPPING.get(x, None))
+
+    result_uri = common_tasks.save_result.with_options(
+        name="dist-alerts-by-land-cover-save-result"
+    )(result_df, result_uri)
+
+    return result_uri

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_land_cover.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_land_cover.py
@@ -29,7 +29,7 @@ def dist_alerts_by_land_cover_area(dist_zarr_uri: str, dist_version: str, overwr
         return result_uri
 
     expected_groups = (
-        np.arange(894),  # country ISO codes
+        np.arange(999),  # country ISO codes
         np.arange(86),  # region codes
         np.arange(854),  # subregion codes
         np.arange(8),  # land cover classes

--- a/pipelines/test/integration/disturbance/conftest.py
+++ b/pipelines/test/integration/disturbance/conftest.py
@@ -136,3 +136,22 @@ def grasslands_ds():
     )
 
     return grasslands
+
+@pytest.fixture
+def land_cover_ds():
+    land_cover = xr.Dataset(
+        data_vars={
+            "band_data": (
+                ("band", "y", "x", "year"),
+                da.array([[[[3, 4], [6, 1]], [[0, 4], [7, 2]]]], dtype=np.uint8),
+            )
+        },
+        coords={
+            "band": ("band", [1], {}),
+            "y": ("y", [60.0, 59.99975], {}),
+            "x": ("x", [-180.0, -179.99975], {}),
+            "year": ("year", [2023, 2024], {}),
+        }
+    )
+
+    return land_cover

--- a/pipelines/test/integration/disturbance/test_gadm_dist_alerts_by_land_cover.py
+++ b/pipelines/test/integration/disturbance/test_gadm_dist_alerts_by_land_cover.py
@@ -1,0 +1,117 @@
+import pytest
+import datetime
+from unittest.mock import patch
+
+from pandera.pandas import DataFrameSchema, Column, Check
+from prefect.testing.utilities import prefect_test_harness
+
+from pipelines.disturbance.prefect_flows import dist_alerts_by_land_cover_area
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@patch("pipelines.prefect_flows.common_stages._save_parquet")
+@patch("pipelines.disturbance.stages._load_zarr")
+def test_gadm_dist_alerts_happy_path(
+    mock_load_zarr,
+    mock_save_parquet,
+    dist_ds,
+    country_ds,
+    region_ds,
+    subregion_ds,
+    pixel_area_ds,
+    land_cover_ds,
+):
+    """Test full workflow with in-memory dependencies"""
+
+    mock_load_zarr.side_effect = [
+        dist_ds,
+        country_ds,
+        region_ds,
+        subregion_ds,
+        pixel_area_ds,
+        land_cover_ds,
+    ]
+
+    with prefect_test_harness():
+        result_uri = dist_alerts_by_land_cover_area(
+            dist_zarr_uri="s3://dummy_zarr_uri",
+            dist_version="test_v1",
+        )
+
+    assert (
+        result_uri
+        == "s3://gfw-data-lake/umd_glad_dist_alerts/test_v1/tabular/zonal_stats/gadm/gadm_adm2_dist_alerts_by_land_cover.parquet"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@patch("pipelines.prefect_flows.common_stages._save_parquet")
+@patch("pipelines.disturbance.stages._load_zarr")
+def test_gadm_dist_alerts_result(
+    mock_load_zarr,
+    mock_save_parquet,
+    dist_ds,
+    country_ds,
+    region_ds,
+    subregion_ds,
+    pixel_area_ds,
+    land_cover_ds,
+):
+    alert_schema = DataFrameSchema(
+        name="GADM Dist Alerts",
+        columns={
+            "country": Column(str, Check.ne("")),
+            "region": Column(int, Check.ge(0)),
+            "subregion": Column(int, Check.ge(0)),
+            "land_cover": Column(str, Check.ne("")),
+            "alert_date": Column(
+                datetime.date,
+                checks=[
+                    Check.greater_than_or_equal_to(datetime.date.fromisoformat("2023-01-01")),
+                    Check.less_than_or_equal_to(datetime.date.fromisoformat("2023-03-11")),
+                ],
+            ),
+            "alert_confidence": Column(str, Check.isin(["low", "high"])),
+            "area__ha": Column("float32", Check.isin([1500.0, 750.0])),
+        },
+        unique=[
+            "country",
+            "region",
+            "subregion",
+            "land_cover",
+            "alert_date",
+            "alert_confidence",
+        ],
+        checks=Check(
+            lambda df: (
+                df.groupby(
+                    ["country", "region", "subregion", "land_cover", "alert_date"]
+                )["alert_confidence"].transform("nunique")
+                == 1
+            ),
+            name="two_confidences_per_group",
+            error="Each location-date must have exactly 1 confidence levels",
+        ),
+    )
+
+    mock_load_zarr.side_effect = [
+        dist_ds,
+        country_ds,
+        region_ds,
+        subregion_ds,
+        pixel_area_ds,
+        land_cover_ds,
+    ]
+
+    with prefect_test_harness():
+        dist_alerts_by_land_cover_area(
+            dist_zarr_uri="s3://dummy_zarr_uri",
+            dist_version="test_v1",
+        )
+
+    # Verify
+    result = mock_save_parquet.call_args[0][0]
+    print(f"\nGADM dist alerts by land_cover result:\n{result}")
+    alert_schema.validate(result)


### PR DESCRIPTION
PZB-148 Analysis/pipeline for dist by land_cover

Similar to the other dist pipelines and analyses.

I have a special case for the pre-calc query, since we are now computing dist areas, rather than counts in the pipeline. I will get rid of the special case when we switch the other pre-calc parquets and queries (soon).

