### PR TITLE
Consistent field names

### DIFF
--- a/api/app/domain/models/dataset.py
+++ b/api/app/domain/models/dataset.py
@@ -12,8 +12,8 @@ class Dataset(Enum):
     def get_field_name(self):
         DATASET_TO_NAMES = {
             Dataset.area_hectares: "area__ha",
-            Dataset.tree_cover_loss: "tree_cover_loss__year",
-            Dataset.canopy_cover: "canopy_cover__percent",
+            Dataset.tree_cover_loss: "tree_cover_loss_year",
+            Dataset.canopy_cover: "canopy_cover",
         }
 
         return DATASET_TO_NAMES[self]

--- a/api/app/domain/models/dataset.py
+++ b/api/app/domain/models/dataset.py
@@ -11,9 +11,9 @@ class Dataset(Enum):
 
     def get_field_name(self):
         DATASET_TO_NAMES = {
-            Dataset.area_hectares: "area_ha",
-            Dataset.tree_cover_loss: "loss_year",
-            Dataset.canopy_cover: "canopy_cover",
+            Dataset.area_hectares: "area__ha",
+            Dataset.tree_cover_loss: "tree_cover_loss__year",
+            Dataset.canopy_cover: "canopy_cover__percent",
         }
 
         return DATASET_TO_NAMES[self]

--- a/api/app/domain/repositories/zarr_dataset_repository.py
+++ b/api/app/domain/repositories/zarr_dataset_repository.py
@@ -57,7 +57,7 @@ class ZarrDatasetRepository:
         if dataset == Dataset.tree_cover_loss:
             return series + 2000
         else:
-            raise NotImplementedError()
+            return series
 
     def _clip_xarr_to_geometry(self, xarr, geom):
         sliced = xarr.sel(

--- a/api/app/models/land_change/tree_cover_loss.py
+++ b/api/app/models/land_change/tree_cover_loss.py
@@ -95,12 +95,12 @@ class TreeCoverLossAnalyticsResponse(Response):
                             "__dtypes__": {
                                 "aoi_id": "str",
                                 "aoi_type": "str",
-                                "tree_cover_loss__year": "int",
+                                "tree_cover_loss_year": "int",
                                 "area__ha": "float",
                             },
                             "aoi_id": ["IDN.24.9", "IDN.14.4", "BRA.1.1"],
                             "aoi_type": ["admin", "admin", "admin"],
-                            "tree_cover_loss__year": [2022, 2023, 2024],
+                            "tree_cover_loss_year": [2022, 2023, 2024],
                             "area__ha": [
                                 4045.406160862687,
                                 4050.4061608627,

--- a/api/app/models/land_change/tree_cover_loss.py
+++ b/api/app/models/land_change/tree_cover_loss.py
@@ -93,27 +93,24 @@ class TreeCoverLossAnalyticsResponse(Response):
                     "data": {
                         "result": {  # column oriented for loading into a dataframe
                             "__dtypes__": {
-                                "country": "str",
-                                "region": "int",
-                                "subregion": "int",
+                                "aoi_id": "str",
+                                "aoi_type": "str",
                                 "tree_cover_loss__year": "int",
-                                "tree_cover_loss__ha": "float",
-                                "gross_emissions_co2e_all_gases__mg": "float",
+                                "area__ha": "float",
                             },
-                            "country": ["BRA", "BRA", "BRA"],
-                            "region": [1, 1, 1],
-                            "subregion": [12, 12, 12],
+                            "aoi_id": ["IDN.24.9", "IDN.14.4", "BRA.1.1"],
+                            "aoi_type": ["admin", "admin", "admin"],
                             "tree_cover_loss__year": [2022, 2023, 2024],
-                            "tree_cover_loss__ha": [
+                            "area__ha": [
                                 4045.406160862687,
                                 4050.4061608627,
                                 4045.406160862687,
                             ],
-                            "gross_emissions_co2e_all_gases__mg": [
-                                3490821.6510292348,
-                                114344.24741739516,
-                                114347.2474174,
-                            ],
+                            # "gross_emissions_co2e_all_gases__mg": [
+                            #     3490821.6510292348,
+                            #     114344.24741739516,
+                            #     114347.2474174,
+                            # ],
                         },
                         "metadata": {
                             "aoi": {

--- a/api/test/integration/analysis/tree_cover_loss/test_tree_cover_loss.py
+++ b/api/test/integration/analysis/tree_cover_loss/test_tree_cover_loss.py
@@ -61,14 +61,14 @@ class TestTclAnalyticsPostWithMultipleAdminAOIs:
         data = await retry_getting_resource("tree_cover_loss", resource_id, client)
 
         df = pd.DataFrame(data["result"])
-        assert "IDN.24.9" in df["id"].values
-        assert "IDN.14" in df["id"].values
-        assert "BRA" in df["id"].values
+        assert "IDN.24.9" in df["aoi_id"].values
+        assert "IDN.14" in df["aoi_id"].values
+        assert "BRA" in df["aoi_id"].values
 
-        assert ~(df.loss_year < 2015).any()
-        assert ~(df.loss_year > 2022).any()
+        assert ~(df.tree_cover_loss_year < 2015).any()
+        assert ~(df.tree_cover_loss_year > 2022).any()
 
-        assert df.columns.size == 3
+        assert df.columns.size == 4
 
 
 class TestTclAnalyticsPostWithKba:
@@ -124,10 +124,10 @@ class TestTclAnalyticsPostWithKba:
         data = await retry_getting_resource("tree_cover_loss", resource_id, client)
 
         df = pd.DataFrame(data["result"])
-        assert "20401" in df["id"].values
-        assert "19426" in df["id"].values
+        assert "20401" in df["aoi_id"].values
+        assert "19426" in df["aoi_id"].values
 
-        assert ~(df.loss_year < 2020).any()
-        assert ~(df.loss_year > 2023).any()
+        assert ~(df.tree_cover_loss_year < 2020).any()
+        assert ~(df.tree_cover_loss_year > 2023).any()
 
-        assert df.columns.size == 3
+        assert df.columns.size == 4

--- a/api/test/integration/test_dist_analytics.py
+++ b/api/test/integration/test_dist_analytics.py
@@ -288,20 +288,23 @@ class TestDistAnalyticsPostWithMultipleAdminAOIs:
 
         expected_df = pd.DataFrame(
             {
-                "country": ["IDN", "IDN", "IDN", "IDN", "BRA"],
-                "region": [24, 24, 14, 14, 1],
-                "subregion": [9, 9, 13, 13, 1],
                 "aoi_id": ["IDN.24.9", "IDN.24.9", "IDN.14.13", "IDN.14.13", "BRA.1.1"],
                 "aoi_type": ["admin"] * 5,
-                "alert_date": [
+                "disturbance_alerts_date": [
                     "2024-08-15",
                     "2024-08-15",
                     "2024-08-15",
                     "2024-08-15",
                     "2024-08-15",
                 ],
-                "confidence": ["high", "low", "high", "low", "high"],
-                "value": [1.133972e+06, 7.154635e+04, 1.064846e+06, 9.065568e+04, 1.547240e+06],
+                "disturbance_alerts_confidence": ["high", "low", "high", "low", "high"],
+                "disturbance_alerts_area__ha": [
+                    1.133972e06,
+                    7.154635e04,
+                    1.064846e06,
+                    9.065568e04,
+                    1.547240e06,
+                ],
             }
         )
 
@@ -390,7 +393,18 @@ class TestDistAnalyticsPostWithMultipleKBAAOIs:
                     "high",
                     "low",
                 ],
-                "value": [1511.152588, 755.576965, 1511.129639, 1511.129639, 755.584412, 3025.184570, 5294.074707, 3781.512695, 756.304932, 755.576294],
+                "value": [
+                    1511.152588,
+                    755.576965,
+                    1511.129639,
+                    1511.129639,
+                    755.584412,
+                    3025.184570,
+                    5294.074707,
+                    3781.512695,
+                    756.304932,
+                    755.576294,
+                ],
                 "aoi_id": [
                     "18392",
                     "18392",
@@ -448,7 +462,7 @@ async def test_gadm_dist_analytics_no_intersection():
                 "2024-08-15",
             ],
             "confidence": ["high", "low"],
-            "value": [1.133972e+06, 7.154635e+04],
+            "value": [1.133972e06, 7.154635e04],
         }
     )
 
@@ -496,6 +510,7 @@ async def test_kba_dist_analytics_no_intersection():
 
     pd.testing.assert_frame_equal(expected_df, actual_df, check_like=True)
 
+
 @pytest.mark.asyncio
 async def test_admin_dist_analytics_by_grasslands():
     delete_resource_files(
@@ -539,6 +554,7 @@ async def test_admin_dist_analytics_by_grasslands():
 
     pd.testing.assert_frame_equal(expected_df, actual_df, check_like=True)
 
+
 @pytest.mark.asyncio
 async def test_admin_dist_analytics_by_land_cover():
     delete_resource_files(
@@ -565,20 +581,83 @@ async def test_admin_dist_analytics_by_land_cover():
 
     expected_df = pd.DataFrame(
         {
-            "country": ["TZA", "TZA", "TZA", "TZA", "TZA", "TZA", ],
-            "region": [24, 24, 24, 24, 24, 24, ],
-            "subregion": [3, 3, 3, 3, 3, 3, ],
-            "land_cover": ["Built-up", "Cropland", "Short vegetation", "Short vegetation", "Tree cover", "Tree cover", ],
-            "alert_date": ["2024-08-15", "2024-08-15", "2024-08-15", "2024-08-16", "2024-08-15", "2024-08-16", ],
-            "confidence": ["high", "high", "high", "high", "high", "high", ],
-            "value": [3073.667969, 7682.643555, 7682.792969, 9989.411133, 2305.148438, 6146.835938, ],
-            "aoi_id": ["TZA.24.3", "TZA.24.3", "TZA.24.3", "TZA.24.3", "TZA.24.3", "TZA.24.3", ],
-            "aoi_type": ["admin", "admin", "admin", "admin", "admin", "admin", ],
+            "country": [
+                "TZA",
+                "TZA",
+                "TZA",
+                "TZA",
+                "TZA",
+                "TZA",
+            ],
+            "region": [
+                24,
+                24,
+                24,
+                24,
+                24,
+                24,
+            ],
+            "subregion": [
+                3,
+                3,
+                3,
+                3,
+                3,
+                3,
+            ],
+            "land_cover": [
+                "Built-up",
+                "Cropland",
+                "Short vegetation",
+                "Short vegetation",
+                "Tree cover",
+                "Tree cover",
+            ],
+            "alert_date": [
+                "2024-08-15",
+                "2024-08-15",
+                "2024-08-15",
+                "2024-08-16",
+                "2024-08-15",
+                "2024-08-16",
+            ],
+            "confidence": [
+                "high",
+                "high",
+                "high",
+                "high",
+                "high",
+                "high",
+            ],
+            "value": [
+                3073.667969,
+                7682.643555,
+                7682.792969,
+                9989.411133,
+                2305.148438,
+                6146.835938,
+            ],
+            "aoi_id": [
+                "TZA.24.3",
+                "TZA.24.3",
+                "TZA.24.3",
+                "TZA.24.3",
+                "TZA.24.3",
+                "TZA.24.3",
+            ],
+            "aoi_type": [
+                "admin",
+                "admin",
+                "admin",
+                "admin",
+                "admin",
+                "admin",
+            ],
         }
     )
 
     actual_df = pd.DataFrame(data["result"])
-    pd.set_option('display.max_columns', None)
+    pd.set_option("display.max_columns", None)
     print(actual_df)
 
     pd.testing.assert_frame_equal(expected_df, actual_df, check_like=True)

--- a/api/test/unit/domain/compute_engines/test_tree_cover_loss_compute_engine.py
+++ b/api/test/unit/domain/compute_engines/test_tree_cover_loss_compute_engine.py
@@ -27,9 +27,9 @@ async def test_get_tree_cover_loss_precalc_handler_happy_path():
                 {
                     "aoi_id": ["BRA", "BRA", "BRA"],
                     "aoi_type": ["admin", "admin", "admin"],
-                    "tree_cover_loss__year": [2015, 2020, 2023],
+                    "tree_cover_loss_year": [2015, 2020, 2023],
                     "area__ha": [1, 10, 100],
-                    "canopy_cover__percent": [20, 30, 50],
+                    "canopy_cover": [20, 30, 50],
                 }
             )
 
@@ -44,12 +44,12 @@ async def test_get_tree_cover_loss_precalc_handler_happy_path():
     )
     results = await aois.get_tree_cover_loss(30, 2020, 2024, "primary_forest")
     assert "BRA" in results.aoi_id.to_list()
-    assert 2020 in results.tree_cover_loss__year.to_list()
-    assert 2023 in results.tree_cover_loss__year.to_list()
+    assert 2020 in results.tree_cover_loss_year.to_list()
+    assert 2023 in results.tree_cover_loss_year.to_list()
     assert 10.0 in results.area__ha.to_list()
     assert 100.0 in results.area__ha.to_list()
-    assert "admin" in results.aoi_type
-    assert results.size == 6
+    assert "admin" in results.aoi_type.to_list()
+    assert results.size == 8
 
 
 @pytest.mark.asyncio
@@ -70,13 +70,13 @@ async def test_flox_handler_happy_path():
                 data = np.hstack([np.ones((10, 5)), np.full((10, 5), 5)])
                 coords = {"x": np.arange(10), "y": np.arange(10)}
                 xarr = xr.DataArray(data, coords=coords, dims=("x", "y"))
-                xarr.name = "canopy_cover__percent"
+                xarr.name = "canopy_cover"
             elif dataset == Dataset.tree_cover_loss:
                 # top half is 15s, bottom half is 5s
                 data = np.vstack([np.full((5, 10), 15), np.full((5, 10), 5)])
                 coords = {"x": np.arange(10), "y": np.arange(10)}
                 xarr = xr.DataArray(data, coords=coords, dims=("x", "y"))
-                xarr.name = "tree_cover_loss__year"
+                xarr.name = "tree_cover_loss_year"
             else:
                 raise ValueError("Not a valid dataset for this test")
 
@@ -102,7 +102,7 @@ async def test_flox_handler_happy_path():
         pd.DataFrame(results),
         pd.DataFrame(
             {
-                "tree_cover_loss__year": [2015],
+                "tree_cover_loss_year": [2015],
                 "area__ha": [12.5],
                 "aoi_id": ["1234"],
                 "aoi_type": ["protected_area"],

--- a/api/test/unit/domain/compute_engines/test_tree_cover_loss_compute_engine.py
+++ b/api/test/unit/domain/compute_engines/test_tree_cover_loss_compute_engine.py
@@ -25,10 +25,11 @@ async def test_get_tree_cover_loss_precalc_handler_happy_path():
         async def execute(self, data_source: str, query: str):
             data_source = pd.DataFrame(
                 {
-                    "id": ["BRA", "BRA", "BRA"],
-                    "loss_year": [2015, 2020, 2023],
-                    "value": [1, 10, 100],
-                    "canopy_cover": [20, 30, 50],
+                    "aoi_id": ["BRA", "BRA", "BRA"],
+                    "aoi_type": ["admin", "admin", "admin"],
+                    "tree_cover_loss__year": [2015, 2020, 2023],
+                    "area__ha": [1, 10, 100],
+                    "canopy_cover__percent": [20, 30, 50],
                 }
             )
 
@@ -42,11 +43,12 @@ async def test_get_tree_cover_loss_precalc_handler_happy_path():
         AdminAreaOfInterest(ids=["BRA", "IDN", "COD"]), compute_engine=compute_engine
     )
     results = await aois.get_tree_cover_loss(30, 2020, 2024, "primary_forest")
-    assert "BRA" in results.id.to_list()
-    assert 2020 in results.loss_year.to_list()
-    assert 2023 in results.loss_year.to_list()
-    assert 10.0 in results.value.to_list()
-    assert 100.0 in results.value.to_list()
+    assert "BRA" in results.aoi_id.to_list()
+    assert 2020 in results.tree_cover_loss__year.to_list()
+    assert 2023 in results.tree_cover_loss__year.to_list()
+    assert 10.0 in results.area__ha.to_list()
+    assert 100.0 in results.area__ha.to_list()
+    assert "admin" in results.aoi_type
     assert results.size == 6
 
 
@@ -62,19 +64,19 @@ async def test_flox_handler_happy_path():
                 data = np.full((10, 10), 0.5)
                 coords = {"x": np.arange(10), "y": np.arange(10)}
                 xarr = xr.DataArray(data, coords=coords, dims=("x", "y"))
-                xarr.name = "area_ha"
+                xarr.name = "area__ha"
             elif dataset == Dataset.canopy_cover:
                 # left half is 1s, right half is 5s
                 data = np.hstack([np.ones((10, 5)), np.full((10, 5), 5)])
                 coords = {"x": np.arange(10), "y": np.arange(10)}
                 xarr = xr.DataArray(data, coords=coords, dims=("x", "y"))
-                xarr.name = "canopy_cover"
+                xarr.name = "canopy_cover__percent"
             elif dataset == Dataset.tree_cover_loss:
                 # top half is 15s, bottom half is 5s
                 data = np.vstack([np.full((5, 10), 15), np.full((5, 10), 5)])
                 coords = {"x": np.arange(10), "y": np.arange(10)}
                 xarr = xr.DataArray(data, coords=coords, dims=("x", "y"))
-                xarr.name = "loss_year"
+                xarr.name = "tree_cover_loss__year"
             else:
                 raise ValueError("Not a valid dataset for this test")
 
@@ -100,9 +102,10 @@ async def test_flox_handler_happy_path():
         pd.DataFrame(results),
         pd.DataFrame(
             {
-                "loss_year": [2015],
-                "area_ha": [12.5],
-                "id": ["1234"],
+                "tree_cover_loss__year": [2015],
+                "area__ha": [12.5],
+                "aoi_id": ["1234"],
+                "aoi_type": ["protected_area"],
             },
         ),
         check_like=True,


### PR DESCRIPTION
- Update tree cover loss API to use consistent field names per our discussion
- Update parquet to also use those as field names
- Move parquet to bucket in the same account so we can avoid downloading the whole file