### PR TITLE
Fix natural lands col

### DIFF
--- a/api/app/analysis/dist_alerts/analysis.py
+++ b/api/app/analysis/dist_alerts/analysis.py
@@ -172,7 +172,7 @@ async def zonal_statistics(aoi, geojson, intersection: Optional[str] = None) -> 
         alerts_df["natural_lands_category"] = alerts_df.natural_lands_class.apply(
             lambda x: "natural" if 1 < x < 12 else "non-natural"
         )
-        alerts_df["natural_lands_class"] = alerts_df.natural_lands_class.apply(
+        alerts_df["natural_land_class"] = alerts_df.natural_lands_class.apply(
             lambda x: NATURAL_LANDS_CLASSES.get(x, "Unclassified")
         )
     elif intersection == "driver":

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_natural_lands.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_natural_lands.py
@@ -53,7 +53,7 @@ def dist_alerts_by_natural_lands_area(dist_zarr_uri: str, dist_version: str, ove
     )(dist_zarr_uri, contextual_uri=contextual_uri)
     compute_input = dist_common_tasks.setup_compute.with_options(
         name="set-up-dist-alerts-by-natural-lands-compute"
-    )(datasets, expected_groups, contextual_name="natural_lands")
+    )(datasets, expected_groups, contextual_name="natural_land_class")
 
     result_dataset = common_tasks.compute_zonal_stat.with_options(
         name="dist-alerts-by-natural-lands-compute-zonal-stats"
@@ -63,7 +63,9 @@ def dist_alerts_by_natural_lands_area(dist_zarr_uri: str, dist_version: str, ove
     )(result_dataset)
 
     # natural_land_class
-    result_df["natural_lands"] = result_df["natural_lands"].apply(lambda x: NATURAL_LANDS_CLASSES.get(x, "Unclassified"))
+    result_df["natural_land_class"] = result_df["natural_land_class"].apply(
+        lambda x: NATURAL_LANDS_CLASSES.get(x, "Unclassified")
+    )
 
     result_uri = common_tasks.save_result.with_options(
         name="dist-alerts-by-natural-lands-save-result"

--- a/pipelines/test/integration/disturbance/test_gadm_dist_alerts_by_natural_lands.py
+++ b/pipelines/test/integration/disturbance/test_gadm_dist_alerts_by_natural_lands.py
@@ -65,12 +65,16 @@ def test_gadm_dist_alerts_result(
             "country": Column(str, Check.ne("")),
             "region": Column(int, Check.ge(0)),
             "subregion": Column(int, Check.ge(0)),
-            "natural_lands": Column(str, Check.ne("")),
+            "natural_land_class": Column(str, Check.ne("")),
             "alert_date": Column(
                 datetime.date,
                 checks=[
-                    Check.greater_than_or_equal_to(datetime.date.fromisoformat("2023-01-01")),
-                    Check.less_than_or_equal_to(datetime.date.fromisoformat("2023-03-11")),
+                    Check.greater_than_or_equal_to(
+                        datetime.date.fromisoformat("2023-01-01")
+                    ),
+                    Check.less_than_or_equal_to(
+                        datetime.date.fromisoformat("2023-03-11")
+                    ),
                 ],
             ),
             "alert_confidence": Column(str, Check.isin(["low", "high"])),

--- a/pipelines/test/integration/disturbance/test_gadm_dist_alerts_by_natural_lands.py
+++ b/pipelines/test/integration/disturbance/test_gadm_dist_alerts_by_natural_lands.py
@@ -84,14 +84,20 @@ def test_gadm_dist_alerts_result(
             "country",
             "region",
             "subregion",
-            "natural_lands",
+            "natural_land_class",
             "alert_date",
             "alert_confidence",
         ],
         checks=Check(
             lambda df: (
                 df.groupby(
-                    ["country", "region", "subregion", "natural_lands", "alert_date"]
+                    [
+                        "country",
+                        "region",
+                        "subregion",
+                        "natural_land_class",
+                        "alert_date",
+                    ]
                 )["alert_confidence"].transform("nunique")
                 == 1
             ),


### PR DESCRIPTION
The api expects `natural_land_class` so updated the pipeline field name from `natural_lands` to match that. THis naming matches what we use for land cover and more descriptive.