### PR TITLE
Add instance to credential chain

### DIFF
--- a/api/app/domain/compute_engines/compute_engine.py
+++ b/api/app/domain/compute_engines/compute_engine.py
@@ -22,7 +22,7 @@ class DuckDbPrecalcQueryService(StrictBaseModel):
             CREATE OR REPLACE SECRET secret (
                 TYPE s3,
                 PROVIDER credential_chain,
-                CHAIN config
+                CHAIN 'instance;env;config'
             );
         """
         )


### PR DESCRIPTION
Getting auth issues for accessing the LCL bucket on the ECS task itself, which is weird, because it has full S3 read access to the account. I suspect the issue is this line, where we say to check the AWS config file for credentials, but the are other sources available. I think in this case we need to also pass 'instance' to use the task role credentials on an AWS instance. Worst case, this doesn't seem cause any issues.