### PR TITLE
pzb-398/move-carbon-flux-resource-to-aws

### DIFF
--- a/api/app/models/land_change/carbon_flux.py
+++ b/api/app/models/land_change/carbon_flux.py
@@ -9,7 +9,7 @@ from app.models.common.areas_of_interest import (
     ProtectedAreaOfInterest,
 )
 from app.models.common.base import Response, StrictBaseModel
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 
 AoiUnion = Union[
     AdminAreaOfInterest,
@@ -23,6 +23,7 @@ AllowedCanopyCover = Literal[30, 50, 75]
 
 
 class CarbonFluxAnalyticsIn(AnalyticsIn):
+    _version: str = PrivateAttr(default="v20250910")
     aoi: Annotated[AoiUnion, Field(discriminator="type")] = Field(
         ...,
         title="AOI",
@@ -79,7 +80,7 @@ class CarbonFluxAnalyticsResponse(Response):
                                 4045.406160862687,
                                 4050.4061608627,
                                 4045.406160862687,
-                            ]
+                            ],
                         },
                         "metadata": {
                             "aoi": {

--- a/api/app/routers/land_change/carbon_flux/carbon_flux.py
+++ b/api/app/routers/land_change/carbon_flux/carbon_flux.py
@@ -1,3 +1,4 @@
+from app.domain.analyzers.carbon_flux_analyzer import CarbonFluxAnalyzer
 from app.domain.repositories.analysis_repository import AnalysisRepository
 from app.infrastructure.persistence.file_system_analysis_repository import (
     FileSystemAnalysisRepository,
@@ -9,7 +10,6 @@ from app.models.land_change.carbon_flux import (
     CarbonFluxAnalyticsIn,
     CarbonFluxAnalyticsResponse,
 )
-from app.domain.analyzers.carbon_flux_analyzer import CarbonFluxAnalyzer
 from app.routers.common_analytics import create_analysis, get_analysis
 from app.use_cases.analysis.analysis_service import AnalysisService
 from fastapi import APIRouter, BackgroundTasks, Depends, Request
@@ -25,8 +25,9 @@ def get_analysis_repository() -> AnalysisRepository:
     return FileSystemAnalysisRepository(ANALYTICS_NAME)
 
 
-def create_analysis_service(request: Request) -> AnalysisService:
-    analysis_repository = get_analysis_repository()
+def create_analysis_service(
+    request: Request, analysis_repository=Depends(get_analysis_repository)
+) -> AnalysisService:
     return AnalysisService(
         analysis_repository=analysis_repository,
         analyzer=CarbonFluxAnalyzer(

--- a/api/app/routers/land_change/carbon_flux/carbon_flux.py
+++ b/api/app/routers/land_change/carbon_flux/carbon_flux.py
@@ -1,7 +1,7 @@
 from app.domain.analyzers.carbon_flux_analyzer import CarbonFluxAnalyzer
 from app.domain.repositories.analysis_repository import AnalysisRepository
-from app.infrastructure.persistence.file_system_analysis_repository import (
-    FileSystemAnalysisRepository,
+from app.infrastructure.persistence.aws_dynamodb_s3_analysis_repository import (
+    AwsDynamoDbS3AnalysisRepository,
 )
 from app.models.common.analysis import AnalyticsOut
 from app.models.common.base import DataMartResourceLinkResponse
@@ -22,7 +22,7 @@ router = APIRouter(prefix=f"/{ANALYTICS_NAME}")
 
 
 def get_analysis_repository() -> AnalysisRepository:
-    return FileSystemAnalysisRepository(ANALYTICS_NAME)
+    return AwsDynamoDbS3AnalysisRepository(ANALYTICS_NAME)
 
 
 def create_analysis_service(


### PR DESCRIPTION
Carbon Flux now saves results to AWS and not the local file system

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Analytics are stored to the tmp directory of the ECS instance

Issue Number: PZB-398


## What is the new behavior?
Analytics are stored in DynamoDB and S3

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

