### PR TITLE
:bug: fix(AnalysisService): save new analysis resource immediately

### DIFF
--- a/api/app/infrastructure/persistence/aws_dynamodb_s3_analysis_repository.py
+++ b/api/app/infrastructure/persistence/aws_dynamodb_s3_analysis_repository.py
@@ -114,7 +114,9 @@ class AwsDynamoDbS3AnalysisRepository(AnalysisRepository):
         ddb_item = {
             "resource_id": resource_id_str,
             "metadata": analytics.metadata,
-            "status": analytics.status.value,  # Store the enum's value (string)
+            "status": analytics.status.value
+            if analytics.status
+            else None,  # Store the enum's value (string)
             "s3_result_key": s3_key,  # Always store the pointer, even if result is None
         }
 

--- a/api/app/routers/common_analytics.py
+++ b/api/app/routers/common_analytics.py
@@ -79,7 +79,7 @@ async def get_analysis(
         )
         raise HTTPException(status_code=500, detail="Internal server error")
 
-    if analysis.status is None:
+    if analysis.metadata is None:
         raise HTTPException(status_code=404, detail="Analysis not found")
 
     match analysis.status:
@@ -91,7 +91,8 @@ async def get_analysis(
         case AnalysisStatus.failed:
             message = "Analysis failed. Result is not available."
         case _:
-            message = ""
+            response.headers["Retry-After"] = "1"
+            message = "Resource is initializing, follow Retry-After header."
 
     return AnalyticsOut(
         status=analysis.status,

--- a/api/app/use_cases/analysis/analysis_service.py
+++ b/api/app/use_cases/analysis/analysis_service.py
@@ -83,12 +83,21 @@ class AnalysisService:
         analysis: Analysis = await self.analysis_repository.load_analysis(
             data.thumbprint()
         )
+
         self.analytics_resource_id = data.thumbprint()
         self.analytics_resource = AnalyticsOut(
             metadata=analysis.metadata or data.model_dump(),
             result=analysis.result,
             status=analysis.status,
         )
+
+        if self.analytics_resource.status is None:  # store placeholder immediately
+            await self.analysis_repository.store_analysis(
+                data.thumbprint(),
+                Analysis(
+                    metadata=self.analytics_resource.metadata, result=None, status=None
+                ),
+            )
 
     def resource_thumbprint(self) -> uuid.UUID:
         return self.analytics_resource_id


### PR DESCRIPTION
As soon as a new AOI is posted to the Analytics Service, it should be saved so that the following requests find the resource.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Pull request type
Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
New analytics requests are saved inside the `BackgroundTask` fastapi process. 
Unfortunately, when a GET is almost instantly requested after the initial POST, the request will respond with `404` since it's highly likely that the `BackgroundTask` hasn't started executing yet.

Issue Number: N/A


## What is the new behavior?
The initial saving of the analytics resource happens in the main thread of the POST request. Therefore, any following GET will find the resource and reply appropriately.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
