### PR TITLE
PZB-418 Use different parquet for carbon flux

### DIFF
--- a/api/app/domain/analyzers/carbon_flux_analyzer.py
+++ b/api/app/domain/analyzers/carbon_flux_analyzer.py
@@ -42,13 +42,13 @@ admin_results_uri = "s3://lcl-analytics/zonal-statistics/admin-carbon2.parquet"
 
 
 def create_gadm_carbon_query(type, gadm_list, threshold):
-    query = f"(select sum(value) from '{admin_results_uri}' where carbontype == '{type}' and country = '{gadm_list[0]}'"
+    query = f"(select sum(value) from '{admin_results_uri}' where carbontype = '{type}' and country = '{gadm_list[0]}'"
     if len(gadm_list) > 1:
         query += f" AND region = {gadm_list[1]}"
     if len(gadm_list) > 2:
         query += f" AND subregion = {gadm_list[2]}"
 
-    query += f"AND tree_cover_density == {threshold}) AS {type}"
+    query += f"AND tree_cover_density = {threshold}) AS {type}"
     return query
 
 

--- a/api/app/domain/analyzers/carbon_flux_analyzer.py
+++ b/api/app/domain/analyzers/carbon_flux_analyzer.py
@@ -34,7 +34,11 @@ tree_cover_loss_zarr_uri = (
 )
 # Parquet location
 # admin_results_uri = "s3://gfw-data-lake/gfw_forest_carbon_net_flux/v20250430/tabular/zonal_stats/gadm/gadm_adm2.parquet"
-admin_results_uri = "s3://lcl-analytics/zonal-statistics/admin-carbon.parquet"
+
+# This is a simpler parquet with just country, region, subregion, tree_cover_density,
+# carbontype, value columns. Use equality on the tree_cover_density column, which has
+# values 30/50/75..
+admin_results_uri = "s3://lcl-analytics/zonal-statistics/admin-carbon2.parquet"
 
 
 def create_gadm_carbon_query(type, gadm_list, threshold):
@@ -44,15 +48,7 @@ def create_gadm_carbon_query(type, gadm_list, threshold):
     if len(gadm_list) > 2:
         query += f" AND subregion = {gadm_list[2]}"
 
-    # emissions should filter by just TCD, but net flux/removals should filter by
-    # TCD, gain and mangroves
-    threshold_pixel_value = ZarrDatasetRepository().translate(
-        Dataset.canopy_cover, threshold
-    )
-    if type == "carbon_gross_emissions":
-        query += f"AND tree_cover_density >= {threshold_pixel_value}) AS {type}"
-    else:
-        query += f" AND (tree_cover_density >= {threshold_pixel_value} or mangrove_stock_2000 > 0 OR tree_cover_gain_from_height > 0)) AS {type}"
+    query += f"AND tree_cover_density == {threshold}) AS {type}"
     return query
 
 

--- a/api/test/integration/test_carbon.py
+++ b/api/test/integration/test_carbon.py
@@ -50,7 +50,7 @@ class TestCarbonDataAdmin:
     @pytest_asyncio.fixture(autouse=True)
     async def setup(self):
         analytics_in = CarbonFluxAnalyticsIn(
-            aoi=AdminAreaOfInterest(type="admin", ids=["NGA.20.31", "IDN.25.3"]),
+            aoi=AdminAreaOfInterest(type="admin", ids=["NGA.20.31", "IDN.25.3", "CHN"]),
             canopy_cover=30,
         )
         app.dependency_overrides[
@@ -87,14 +87,23 @@ class TestCarbonDataAdmin:
 
         expected = pd.DataFrame(
             {
-                "aoi_id": ["NGA.20.31", "IDN.25.3"],
-                "aoi_type": ["admin", "admin"],
-                "carbon_net_flux_Mg_CO2e": [-12.349344253540039, 24370083.802587524],
+                "aoi_id": ["NGA.20.31", "IDN.25.3", "CHN"],
+                "aoi_type": ["admin", "admin", "admin"],
+                "carbon_net_flux_Mg_CO2e": [
+                    -12.349344253540039,
+                    24370083.802587524,
+                    -11422581500.146715,
+                ],
                 "carbon_gross_removals_Mg_CO2e": [
                     12.349344253540039,
                     28127167.23389721,
+                    17417177319.904095,
                 ],
-                "carbon_gross_emissions_Mg_CO2e": [None, 52405364.698329926],
+                "carbon_gross_emissions_Mg_CO2e": [
+                    0.0,
+                    52496919.891059,
+                    5994595888.622183,
+                ],
             }
         )
 


### PR DESCRIPTION
PZB-418 Use different parquet for carbon flux

We're not sure why carbon flux results for all of China are wrong  - it might be because of the float32 issue.
(May need to make the carbon flux zarrs be float64.)

But for now, Justin gave me a CSV derived from Geotrellis results that I massaged into a new, simpler parquet
s3://lcl-analytics/zonal-statistics/admin-carbon2.parquet . This now gives the correct results for all of China, and basically same results for NGA.20.31 and IDN.25.3
