### PR TITLE
Fix broken validate_zonal_statistics.

### DIFF
--- a/pipelines/disturbance/validate_dist_input.py
+++ b/pipelines/disturbance/validate_dist_input.py
@@ -1,8 +1,8 @@
-import xarray as xr
 import numpy as np
-
+import xarray as xr
 
 DIST_COUNT_THRESHOLD = 5
+
 
 def validates_dist_input(curr_cog_uri: str, prev_cog_uri: str) -> None:
     """
@@ -14,8 +14,11 @@ def validates_dist_input(curr_cog_uri: str, prev_cog_uri: str) -> None:
     prev_dist_alerts = _read_from_cog(prev_cog_uri)
 
     assert _check_percent_diff(curr_dist_alerts, prev_dist_alerts, DIST_COUNT_THRESHOLD)
-    
-def _check_percent_diff(da1: xr.DataArray, da2: xr.DataArray, diff_threshold: float) -> bool:
+
+
+def _check_percent_diff(
+    da1: xr.DataArray, da2: xr.DataArray, diff_threshold: float
+) -> bool:
     stat1 = da1.count()
     stat2 = da2.count()
 
@@ -25,14 +28,13 @@ def _check_percent_diff(da1: xr.DataArray, da2: xr.DataArray, diff_threshold: fl
 
 def _read_from_cog(cog_uri: str):
     """
-    Read COG to an xarray. Using chunking the aligns with COG internal tiling for faster stats, since 
+    Read COG to an xarray. Using chunking the aligns with COG internal tiling for faster stats, since
     this read isn't being used for converting to zarr.
     """
-    dist_alerts = xr.open_dataset(
-        cog_uri,
-        chunks={'x': 8192, 'y':8192}
-    ).astype(np.int16).band_data
+    dist_alerts = (
+        xr.open_dataset(cog_uri, chunks={"x": 8192, "y": 8192})
+        .astype(np.int16)
+        .band_data
+    )
 
     return dist_alerts
-
-

--- a/pipelines/disturbance/validate_zonal_statistics.py
+++ b/pipelines/disturbance/validate_zonal_statistics.py
@@ -11,6 +11,7 @@ from pandera.typing.pandas import Series
 from prefect import task
 from prefect.logging import get_run_logger
 from rasterio.features import geometry_mask
+from rasterio.windows import from_bounds
 
 from pipelines.disturbance.check_for_new_alerts import get_latest_version
 
@@ -682,10 +683,24 @@ def generate_validation_statistics(version: str) -> pd.DataFrame:
 
     # reorder columns to country, region, subregion, dist_alert_date, confidence, value
     high_conf_results = high_conf_results[
-        ["country", "region", "subregion", "dist_alert_date", "confidence", "area_ha"]
+        [
+            "country",
+            "region",
+            "subregion",
+            "dist_alert_date",
+            "dist_alert_confidence",
+            "area_ha",
+        ]
     ]
     low_conf_results = low_conf_results[
-        ["country", "region", "subregion", "dist_alert_date", "confidence", "area_ha"]
+        [
+            "country",
+            "region",
+            "subregion",
+            "dist_alert_date",
+            "dist_alert_confidence",
+            "area_ha",
+        ]
     ]
 
     # concatenate dist_alert_confidence dfs into one validation df


### PR DESCRIPTION
Fix broken validate_zonal_statistics.

In Justin's final rename of columns, missed renaming 'confidence' -> 'dist_alerts_confidence' in a few places. Also, important import was removed, not sure if that was done by the reformatter?  Now validation succeeds again.

Sorry, 'black' decided to reformat some other code too.
