### PR TITLE
Carbon validation

### DIFF
--- a/pipelines/carbon_flux/prefect_flows/carbon_flow.py
+++ b/pipelines/carbon_flux/prefect_flows/carbon_flow.py
@@ -61,4 +61,7 @@ def gadm_carbon_flux(overwrite: bool = False):
     result_uri = common_tasks.save_result.with_options(name="carbon-flux-save-result")(
         result_df, result_uri
     )
+    carbon_tasks.qc_against_validation_source.with_options(
+        name="carbon-flux-qc"
+    )(result_df)
     return result_uri

--- a/pipelines/carbon_flux/prefect_flows/carbon_tasks.py
+++ b/pipelines/carbon_flux/prefect_flows/carbon_tasks.py
@@ -44,3 +44,8 @@ def setup_compute(
 @task
 def postprocess_result(result: xr.DataArray):
     return stages.create_result_dataframe(result)
+
+
+@task
+def qc_against_validation_source(result_df) -> bool:
+    return stages.qc_against_validation_source(result_df)

--- a/pipelines/carbon_flux/stages.py
+++ b/pipelines/carbon_flux/stages.py
@@ -2,6 +2,7 @@ from typing import Callable, Dict, Optional, Tuple
 
 import pandas as pd
 import xarray as xr
+from shapely.geometry import Polygon
 
 from pipelines.globals import (
     ANALYTICS_BUCKET,
@@ -16,7 +17,12 @@ from pipelines.prefect_flows.common_stages import (
 from pipelines.prefect_flows.common_stages import create_zarrs as common_create_zarrs
 from pipelines.prefect_flows.common_stages import (
     rollup_by_gadm_and_convert_to_aoi,
+    symmetric_relative_difference,
 )
+from pipelines.repositories.google_earth_engine_dataset_repository import (
+    GoogleEarthEngineDatasetRepository,
+)
+from pipelines.repositories.qc_feature_repository import QCFeaturesRepository
 
 PIPELINE_CHUNK_SIZE = 10_000
 OTF_CHUNK_SIZE = 4_000
@@ -245,3 +251,91 @@ def create_result_dataframe(alerts_count: xr.DataArray) -> pd.DataFrame:
 
 def _load_zarr(zarr_uri, group=None):
     return xr.open_zarr(zarr_uri, group=group)
+def qc_against_validation_source(
+    result_df: pd.DataFrame,
+    qc_feature_repository=None,
+    gee_repository=None,
+    qc_error_threshold: float = 0.05,
+) -> bool:
+    if qc_feature_repository is None:
+        qc_feature_repository = QCFeaturesRepository()
+    if gee_repository is None:
+        gee_repository = GoogleEarthEngineDatasetRepository()
+
+    qc_features = qc_feature_repository.load(limit=20)
+
+    def qc_feature(row):
+        print(f"Starting QC on GID {row.GID_2}")
+        admin2_aoi_id = row.GID_2.split("_")[0]
+        sample = result_df[
+            (result_df.aoi_id == admin2_aoi_id) & (result_df.tree_cover_density == 30)
+        ]
+
+        if sample.size > 0:
+            sample_emissions = sample[
+                sample.carbontype == "carbon_gross_emissions"
+            ].value.sum()
+            sample_removals = sample[
+                sample.carbontype == "carbon_gross_removals"
+            ].value.sum()
+        else:
+            sample_emissions = 0
+            sample_removals = 0
+
+        validation = get_carbon_validation_statistics(row.geometry, gee_repository)
+
+        diff_emissions = symmetric_relative_difference(
+            validation["emissions_Mg_CO2e"], sample_emissions
+        )
+        diff_removals = symmetric_relative_difference(
+            validation["removals_Mg_CO2e"], sample_removals
+        )
+
+        r = pd.Series(
+            {
+                "pass": bool(
+                    diff_emissions < qc_error_threshold
+                    and diff_removals < qc_error_threshold
+                ),
+                "sample_emissions": sample_emissions,
+                "validation_emissions": validation["emissions_Mg_CO2e"],
+                "sample_removals": sample_removals,
+                "validation_removals": validation["removals_Mg_CO2e"],
+            }
+        )
+        print(f"\n{row.GID_2}\n{r}")
+        return r
+
+    qc_features[
+        [
+            "qc_pass",
+            "sample_emissions",
+            "validation_emissions",
+            "sample_removals",
+            "validation_removals",
+        ]
+    ] = qc_features.apply(qc_feature, axis=1)
+
+    return bool(qc_features.qc_pass.all())
+
+
+def get_carbon_validation_statistics(
+    geom: Polygon,
+    gee_repository=None,
+) -> Dict[str, float]:
+    if gee_repository is None:
+        gee_repository = GoogleEarthEngineDatasetRepository()
+
+    emissions = gee_repository.load("carbon_gross_emissions", geom)
+    removals = gee_repository.load("carbon_gross_removals", geom)
+
+    area_ha = gee_repository.load("area", geom, like=emissions.b1)["area"] / 10000
+
+    emissions_total = float((emissions.b1 * area_ha).sum(skipna=True).item())
+    removals_total = float((removals.b1 * area_ha).sum(skipna=True).item())
+
+    return {
+        "emissions_Mg_CO2e": emissions_total,
+        "removals_Mg_CO2e": removals_total,
+    }
+

--- a/pipelines/carbon_flux/stages.py
+++ b/pipelines/carbon_flux/stages.py
@@ -251,11 +251,13 @@ def create_result_dataframe(alerts_count: xr.DataArray) -> pd.DataFrame:
 
 def _load_zarr(zarr_uri, group=None):
     return xr.open_zarr(zarr_uri, group=group)
+
+
 def qc_against_validation_source(
     result_df: pd.DataFrame,
     qc_feature_repository=None,
     gee_repository=None,
-    qc_error_threshold: float = 0.05,
+    qc_error_threshold: float = 0.02,
 ) -> bool:
     if qc_feature_repository is None:
         qc_feature_repository = QCFeaturesRepository()

--- a/pipelines/prefect_flows/common_stages.py
+++ b/pipelines/prefect_flows/common_stages.py
@@ -412,6 +412,12 @@ def rollup_by_gadm_and_convert_to_aoi(df, groupby_list):
     return results_with_ids
 
 
+# for TCL and carbon validation
+def symmetric_relative_difference(a, b):
+    avg = (abs(a) + abs(b)) / 2
+    return 0 if avg == 0 else abs(a - b) / avg
+
+
 def save_results(df: pd.DataFrame, results_uri: str) -> str:
     print("Starting parquet")
 

--- a/pipelines/repositories/google_earth_engine_dataset_repository.py
+++ b/pipelines/repositories/google_earth_engine_dataset_repository.py
@@ -11,11 +11,11 @@ class GoogleEarthEngineDatasetRepository:
     # lazy load ee assets since ee may not be initiazed yet
     EE_ASSETS = {
         "loss": lambda: ee.Image("UMD/hansen/global_forest_change_2024_v1_12"),
-        "tcl_drivers": lambda: ee.Image(
-            "projects/landandcarbon/assets/wri_gdm_drivers_forest_loss_1km/v1_2_2001_2024"
-        ),
+        "tcl_drivers": lambda: ee.Image("projects/landandcarbon/assets/wri_gdm_drivers_forest_loss_1km/v1_2_2001_2024"),
         "area": lambda: ee.Image.pixelArea(),
         "natural_lands": lambda: ee.Image("WRI/SBTN/naturalLands/v1_1/2020"),
+        "carbon_gross_emissions": lambda: ee.Image("projects/forma-250/assets/gfw_forest_carbon_gross_emissions/gross_emissions_forest_extent_per_hectare_v1_4_2_2001_2024"),
+        "carbon_gross_removals": lambda: ee.Image("projects/forma-250/assets/gfw_forest_carbon_gross_removals/gross_removals_forest_extent_per_hectare_v1_4_2_2001_2024"),
     }
 
     def __init__(self, default_scale=0.00025, default_projection="EPSG:4326"):

--- a/pipelines/repositories/google_earth_engine_dataset_repository.py
+++ b/pipelines/repositories/google_earth_engine_dataset_repository.py
@@ -48,7 +48,8 @@ class GoogleEarthEngineDatasetRepository:
             gee_service_account_b64 = os.getenv("GEE_SERVICE_ACCOUNT_JSON")
             if gee_service_account_b64:
                 gee_service_account = json.loads(
-                    base64.b64decode(gee_service_account_b64).decode("utf-8")
+                    base64.b64decode(gee_service_account_b64).decode("utf-8"),
+                    strict=False,
                 )
                 creds = ee.ServiceAccountCredentials(
                     gee_service_account["client_email"],

--- a/pipelines/test/integration/carbon_flux/conftest.py
+++ b/pipelines/test/integration/carbon_flux/conftest.py
@@ -1,0 +1,123 @@
+import dask.array as da
+import geopandas as gpd
+import numpy as np
+import pytest
+import xarray as xr
+from shapely.geometry import box
+
+
+def _make_band_dataset(values, dtype):
+    return xr.Dataset(
+        data_vars={
+            "band_data": (
+                ("band", "y", "x"),
+                da.from_array(np.array(values, dtype=dtype)),
+            )
+        },
+        coords={
+            "band": np.array([0], dtype=np.int16),
+            "y": np.array([1.0, 0.0], dtype=np.float64),
+            "x": np.array([0.0, 1.0], dtype=np.float64),
+        },
+    )
+
+
+@pytest.fixture
+def carbon_net_flux_ds():
+    return _make_band_dataset([[[1.0, -1.0], [-2.0, 2.0]]], np.float64)
+
+
+@pytest.fixture
+def carbon_gross_removals_ds():
+    return _make_band_dataset([[[-5.0, -10.0], [-15.0, -20.0]]], np.float64)
+
+
+@pytest.fixture
+def carbon_gross_emissions_ds():
+    return _make_band_dataset([[[10.0, 20.0], [30.0, 40.0]]], np.float64)
+
+
+@pytest.fixture
+def tree_cover_density_ds():
+    # Values 5, 6, 7 map to 30%, 50%, 75%; 0 maps to <30%
+    return _make_band_dataset([[[5, 6], [7, 0]]], np.uint8)
+
+
+@pytest.fixture
+def mangrove_ds():
+    return _make_band_dataset([[[0, 1], [0, 0]]], np.uint8)
+
+
+@pytest.fixture
+def tree_cover_gain_ds():
+    return _make_band_dataset([[[0, 0], [1, 0]]], np.uint8)
+
+
+@pytest.fixture
+def country_ds():
+    return _make_band_dataset([[[4, 4], [4, 4]]], np.int16)
+
+
+@pytest.fixture
+def region_ds():
+    return _make_band_dataset([[[1, 1], [1, 1]]], np.uint8)
+
+
+@pytest.fixture
+def subregion_ds():
+    return _make_band_dataset([[[1, 1], [1, 1]]], np.int16)
+
+
+class FakeCarbonQCRepository:
+    def load(self, limit=None):
+        return gpd.GeoDataFrame({"geometry": [box(0, 0, 1, 1)], "GID_2": ["AFG.1.1_1"]})
+
+    def write_results(self, results, analysis, version):
+        pass
+
+
+class FakeCarbonGEERepository:
+    """Returns synthetic GEE data for carbon validation assets.
+
+    emissions per-ha values: [[10, 20], [30, 40]]
+    removals per-ha values:  [[5,  10], [15, 20]]
+    area per pixel (m²):     [[10000, 10000], [10000, 10000]]
+
+    Expected totals (area_ha = area / 10000 = 1.0 per pixel):
+        emissions_Mg_CO2e = 10 + 20 + 30 + 40 = 100.0
+        removals_Mg_CO2e  =  5 + 10 + 15 + 20 =  50.0
+    """
+
+    def load(self, dataset, geometry, like=None):
+        coords = {"y": np.array([0.5, 1.5]), "x": np.array([0.5, 1.5])}
+        if dataset == "carbon_gross_emissions":
+            return xr.Dataset(
+                {
+                    "b1": xr.DataArray(
+                        np.array([[10.0, 20.0], [30.0, 40.0]], dtype=np.float32),
+                        dims=("y", "x"),
+                        coords=coords,
+                    )
+                }
+            )
+        if dataset == "carbon_gross_removals":
+            return xr.Dataset(
+                {
+                    "b1": xr.DataArray(
+                        np.array([[5.0, 10.0], [15.0, 20.0]], dtype=np.float32),
+                        dims=("y", "x"),
+                        coords=coords,
+                    )
+                }
+            )
+        if dataset == "area":
+            return xr.Dataset(
+                {
+                    "area": xr.DataArray(
+                        np.array([[10000.0, 10000.0], [10000.0, 10000.0]], dtype=np.float32),
+                        dims=("y", "x"),
+                        coords=coords,
+                    )
+                }
+            )
+        raise ValueError(f"Unknown dataset: {dataset}")

--- a/pipelines/test/integration/carbon_flux/test_carbon_flow.py
+++ b/pipelines/test/integration/carbon_flux/test_carbon_flow.py
@@ -1,0 +1,108 @@
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+from prefect.testing.utilities import prefect_test_harness
+
+from pipelines.carbon_flux.prefect_flows.carbon_flow import gadm_carbon_flux
+from pipelines.carbon_flux.stages import qc_against_validation_source
+from pipelines.test.integration.carbon_flux.conftest import (
+    FakeCarbonGEERepository,
+    FakeCarbonQCRepository,
+)
+
+
+@pytest.mark.integration
+@patch("pipelines.carbon_flux.stages.qc_against_validation_source", return_value=True)
+@patch("pipelines.prefect_flows.common_stages._save_parquet")
+@patch("pipelines.carbon_flux.stages._load_zarr")
+@patch("pipelines.carbon_flux.stages.create_zarrs")
+def test_carbon_flow_with_mocked_data(
+    mock_create_zarrs,
+    mock_load_zarr,
+    mock_save_parquet,
+    mock_qc,
+    carbon_net_flux_ds,
+    carbon_gross_removals_ds,
+    carbon_gross_emissions_ds,
+    country_ds,
+    region_ds,
+    subregion_ds,
+    mangrove_ds,
+    tree_cover_gain_ds,
+    tree_cover_density_ds,
+):
+    mock_create_zarrs.return_value = {
+        "carbon_net_flux": "s3://mock/carbon_net_flux.zarr",
+        "carbon_gross_removals": "s3://mock/carbon_gross_removals.zarr",
+        "carbon_gross_emissions": "s3://mock/carbon_gross_emissions.zarr",
+    }
+    # Must match the call order in stages.load_data:
+    # net_flux, gross_removals, gross_emissions, country, region, subregion,
+    # mangrove, tree_cover_gain, tree_cover_density
+    mock_load_zarr.side_effect = [
+        carbon_net_flux_ds,
+        carbon_gross_removals_ds,
+        carbon_gross_emissions_ds,
+        country_ds,
+        region_ds,
+        subregion_ds,
+        mangrove_ds,
+        tree_cover_gain_ds,
+        tree_cover_density_ds,
+    ]
+
+    with prefect_test_harness():
+        gadm_carbon_flux(overwrite=True)
+
+    result_df = mock_save_parquet.call_args[0][0]
+
+    expected_columns = {"aoi_id", "aoi_type", "tree_cover_density", "carbontype", "value"}
+    assert set(result_df.columns) == expected_columns
+
+    assert set(result_df["carbontype"].unique()).issubset(
+        {"carbon_net_flux", "carbon_gross_removals", "carbon_gross_emissions"}
+    )
+    assert set(result_df["tree_cover_density"].unique()).issubset({30, 50, 75})
+    assert result_df["value"].dtype.kind == "f"
+
+
+def test_qc_against_validation_source_with_fake_gee_repo():
+    # Matches FakeCarbonGEERepository expected totals exactly:
+    #   emissions = 100.0 Mg CO2e, removals = 50.0 Mg CO2e
+    result_df_matching = pd.DataFrame(
+        {
+            "aoi_id": ["AFG.1.1", "AFG.1.1"],
+            "aoi_type": ["admin2", "admin2"],
+            "tree_cover_density": [30, 30],
+            "carbontype": ["carbon_gross_emissions", "carbon_gross_removals"],
+            "value": [100.0, 50.0],
+        }
+    )
+    assert (
+        qc_against_validation_source(
+            result_df_matching,
+            qc_feature_repository=FakeCarbonQCRepository(),
+            gee_repository=FakeCarbonGEERepository(),
+        )
+        is True
+    )
+
+    # Values diverge significantly from GEE validation (2x > 5% threshold) → fail
+    result_df_diverged = pd.DataFrame(
+        {
+            "aoi_id": ["AFG.1.1", "AFG.1.1"],
+            "aoi_type": ["admin2", "admin2"],
+            "tree_cover_density": [30, 30],
+            "carbontype": ["carbon_gross_emissions", "carbon_gross_removals"],
+            "value": [200.0, 100.0],
+        }
+    )
+    assert (
+        qc_against_validation_source(
+            result_df_diverged,
+            qc_feature_repository=FakeCarbonQCRepository(),
+            gee_repository=FakeCarbonGEERepository(),
+        )
+        is False
+    )

--- a/pipelines/tree_cover_loss/stages.py
+++ b/pipelines/tree_cover_loss/stages.py
@@ -19,6 +19,7 @@ from pipelines.prefect_flows.common_stages import create_zarrs as common_create_
 from pipelines.prefect_flows.common_stages import (
     numeric_to_alpha3,
     rollup_by_gadm_and_convert_to_aoi,
+    symmetric_relative_difference,
 )
 from pipelines.repositories.google_earth_engine_dataset_repository import (
     GoogleEarthEngineDatasetRepository,
@@ -352,11 +353,6 @@ def postprocess_result(result: xr.DataArray) -> pd.DataFrame:
     return results_with_ids
 
 
-def _symmetric_relative_difference(a, b):
-    avg = (abs(a) + abs(b)) / 2
-    return 0 if avg == 0 else abs(a - b) / avg
-
-
 # In Justin's original QC feature file (now at
 # s3://lcl-analytics/vectors/qc_features.geojson.orig), only 3 features in the
 # first 55 did not pass. Those GADM2 areas are listed in bug GTC-3496 to
@@ -412,10 +408,10 @@ def qc_against_validation_source(
         else:
             validation_natural_forests_ha_total = 0
 
-        diff_driver = _symmetric_relative_difference(
+        diff_driver = symmetric_relative_difference(
             validation_driver_area_ha_total, sample_driver_area_ha_total
         )
-        diff_natural_forest = _symmetric_relative_difference(
+        diff_natural_forest = symmetric_relative_difference(
             validation_natural_forests_ha_total, sample_natural_forests_ha_total
         )
 


### PR DESCRIPTION
- Adds a QC step to the carbon flux pipeline that validates pipeline output against GEE reference data, mirroring the existing TCL validation.
- Adds qc_against_validation_source and get_carbon_validation_statistics to carbon_flux/stages.py, comparing pipeline emissions/removals totals against GEE at a 2% threshold
- Registers carbon GEE assets in GoogleEarthEngineDatasetRepository
- Extracts _symmetric_relative_difference from TCL stages into common_stages so both pipelines share it
- Adds integration tests covering the full flow with mocked zarrs and the QC validation logic end-to-end with a fake GEE repo