### PR TITLE
Fix carbon pipeline to put carbon parquet in correct version folder.

### DIFF
--- a/api/app/domain/analyzers/carbon_flux_analyzer.py
+++ b/api/app/domain/analyzers/carbon_flux_analyzer.py
@@ -23,7 +23,7 @@ INPUT_URIS = {
         "tree_cover_gain_from_height_zarr_uri": "s3://gfw-data-lake/umd_tree_cover_gain_from_height/v20240126/raster/epsg-4326/zarr/period.zarr/",
         # Value [0, 100] inclusive.
         "tree_cover_density_2000_zarr_uri": "s3://gfw-data-lake/umd_tree_cover_density_2000/v1.8/raster/epsg-4326/zarr/threshold.zarr/",
-        "admin_results_uri": "s3://lcl-analytics/zonal-statistics/forest-carbon/v1.12/admin-carbon.parquet",
+        "admin_results_uri": "s3://lcl-analytics/zonal-statistics/forest-carbon/v1.13/admin-carbon.parquet",
     },
     Environment.production: {
         # These are zarrs with total emissions (not per-hectare)

--- a/pipelines/carbon_flux/prefect_flows/carbon_flow.py
+++ b/pipelines/carbon_flux/prefect_flows/carbon_flow.py
@@ -14,14 +14,14 @@ from pipelines.globals import (
 
 
 @flow(name="Carbon flux")
-def gadm_carbon_flux(overwrite: bool = False):
+def gadm_carbon_flux(version: str, overwrite: bool = False):
     logging.getLogger("distributed.client").setLevel(logging.ERROR)  # or logging.ERROR
 
     carbon_zarr_uris = carbon_tasks.create_zarrs.with_options(
         name="create-carbon-zarrs"
     )(overwrite=overwrite)
 
-    result_uri = "s3://lcl-analytics/zonal-statistics/admin-carbon.parquet"
+    result_uri = "s3://lcl-analytics/zonal-statistics/forest-carbon/{version}/admin-carbon.parquet"
 
     if not overwrite and s3_uri_exists(result_uri):
         return result_uri

--- a/pipelines/carbon_flux/prefect_flows/carbon_flow.py
+++ b/pipelines/carbon_flux/prefect_flows/carbon_flow.py
@@ -21,7 +21,7 @@ def gadm_carbon_flux(version: str, overwrite: bool = False):
         name="create-carbon-zarrs"
     )(overwrite=overwrite)
 
-    result_uri = "s3://lcl-analytics/zonal-statistics/forest-carbon/{version}/admin-carbon.parquet"
+    result_uri = f"s3://lcl-analytics/zonal-statistics/forest-carbon/{version}/admin-carbon.parquet"
 
     if not overwrite and s3_uri_exists(result_uri):
         return result_uri

--- a/pipelines/carbon_flux/stages.py
+++ b/pipelines/carbon_flux/stages.py
@@ -234,7 +234,20 @@ def create_result_dataframe(alerts_count: xr.DataArray) -> pd.DataFrame:
 
     df = rollup_by_gadm_and_convert_to_aoi(df, ["tree_cover_density", "carbontype"])
 
-    return df
+    # Pivot the carbon values to be their own columns based on the carbon type.
+    df_pivoted = df.pivot_table(
+        index=['tree_cover_density', 'aoi_id', 'aoi_type'],
+        columns='carbontype',
+        values='value'
+    ).reset_index()
+
+    carbon_cols = ['carbon_gross_emissions', 'carbon_gross_removals', 'carbon_net_flux']
+    df_pivoted = df_pivoted.rename(columns={col: f"{col}_Mg_CO2e" for col in carbon_cols})
+
+    # Remove the name of the columns axis (clean up the header)
+    df_pivoted.columns.name = None
+
+    return df_pivoted
 
 
 def _load_zarr(zarr_uri, group=None):

--- a/pipelines/carbon_flux/stages.py
+++ b/pipelines/carbon_flux/stages.py
@@ -328,4 +328,3 @@ def get_carbon_validation_statistics(
         "emissions_Mg_CO2e": emissions_total,
         "removals_Mg_CO2e": removals_total,
     }
-

--- a/pipelines/run_updates.py
+++ b/pipelines/run_updates.py
@@ -59,7 +59,7 @@ def run_dist_update(version=None, overwrite=False, is_latest=False) -> list[str]
 def run_tcl_update(version, overwrite=False, is_latest=False) -> list[str]:
     result_uris = []
 
-    carbon_result = carbon_flow.gadm_carbon_flux(overwrite=overwrite)
+    carbon_result = carbon_flow.gadm_carbon_flux(version, overwrite=overwrite)
     result_uris.append(carbon_result)
 
     tcl_result = tcl_flow.umd_tree_cover_loss_flow(version, overwrite=overwrite)

--- a/pipelines/test/integration/carbon_flux/test_carbon_flow.py
+++ b/pipelines/test/integration/carbon_flux/test_carbon_flow.py
@@ -57,14 +57,11 @@ def test_carbon_flow_with_mocked_data(
 
     result_df = mock_save_parquet.call_args[0][0]
 
-    expected_columns = {"aoi_id", "aoi_type", "tree_cover_density", "carbontype", "value"}
+    expected_columns = {'aoi_type', 'carbon_gross_emissions_Mg_CO2e', 'aoi_id', 'carbon_gross_removals_Mg_CO2e', 'tree_cover_density', 'carbon_net_flux_Mg_CO2e'}
     assert set(result_df.columns) == expected_columns
 
-    assert set(result_df["carbontype"].unique()).issubset(
-        {"carbon_net_flux", "carbon_gross_removals", "carbon_gross_emissions"}
-    )
     assert set(result_df["tree_cover_density"].unique()).issubset({30, 50, 75})
-    assert result_df["value"].dtype.kind == "f"
+    assert result_df["carbon_gross_emissions_Mg_CO2e"].dtype.kind == "f"
 
 
 def test_qc_against_validation_source_with_fake_gee_repo():

--- a/pipelines/test/integration/carbon_flux/test_carbon_flow.py
+++ b/pipelines/test/integration/carbon_flux/test_carbon_flow.py
@@ -53,7 +53,7 @@ def test_carbon_flow_with_mocked_data(
     ]
 
     with prefect_test_harness():
-        gadm_carbon_flux(overwrite=True)
+        gadm_carbon_flux(version="test_version", overwrite=True)
 
     result_df = mock_save_parquet.call_args[0][0]
 


### PR DESCRIPTION
Fix carbon pipeline to put carbon parquet in correct version folder.

The carbon zarrs are already fixed at using versions v20260327 from the data-lake and generating the same version v20260327 zarrs. So, the carbon parquet and the carbon in the TCL parquet will only be correct for version 1.13 (TCL 2025), which is all we want/need at point.

