### PR TITLE
Adjust TCL pipeline post-processing to allow >= query for carbon

### DIFF
--- a/api/app/domain/analyzers/tree_cover_loss_analyzer.py
+++ b/api/app/domain/analyzers/tree_cover_loss_analyzer.py
@@ -29,6 +29,7 @@ INPUT_URIS: Dict[Environment, Dict[str, str]] = {
                 Dataset.tree_cover_loss_drivers,
             ]
         },
+        # Should match result_uri in tcl_flow.py in pipelines.
         "admin_results_uri": "s3://lcl-analytics/zonal-statistics/tcl/v1.13/admin-tree-cover-loss_v20260424.parquet",
     },
     Environment.production: {

--- a/api/app/domain/analyzers/tree_cover_loss_analyzer.py
+++ b/api/app/domain/analyzers/tree_cover_loss_analyzer.py
@@ -44,7 +44,7 @@ INPUT_URIS: Dict[Environment, Dict[str, str]] = {
             ]
         },
         # Should match result_uri in tcl_flow.py in pipelines.
-        "admin_results_uri": "s3://lcl-analytics/zonal-statistics/tcl/v1.13/admin-tree-cover-loss_v20260512.parquet",
+        "admin_results_uri": "s3://lcl-analytics/zonal-statistics/tcl/v1.13/admin-tree-cover-loss_v20260424.parquet",
     },
 }
 

--- a/pipelines/carbon_flux/stages.py
+++ b/pipelines/carbon_flux/stages.py
@@ -275,12 +275,8 @@ def qc_against_validation_source(
         ]
 
         if sample.size > 0:
-            sample_emissions = sample[
-                sample.carbontype == "carbon_gross_emissions"
-            ].value.sum()
-            sample_removals = sample[
-                sample.carbontype == "carbon_gross_removals"
-            ].value.sum()
+            sample_emissions = sample["carbon_gross_emissions_Mg_CO2e"].sum()
+            sample_removals = sample["carbon_gross_removals_Mg_CO2e"].sum()
         else:
             sample_emissions = 0
             sample_removals = 0

--- a/pipelines/test/integration/carbon_flux/test_carbon_flow.py
+++ b/pipelines/test/integration/carbon_flux/test_carbon_flow.py
@@ -69,11 +69,11 @@ def test_qc_against_validation_source_with_fake_gee_repo():
     #   emissions = 100.0 Mg CO2e, removals = 50.0 Mg CO2e
     result_df_matching = pd.DataFrame(
         {
-            "aoi_id": ["AFG.1.1", "AFG.1.1"],
-            "aoi_type": ["admin2", "admin2"],
-            "tree_cover_density": [30, 30],
-            "carbontype": ["carbon_gross_emissions", "carbon_gross_removals"],
-            "value": [100.0, 50.0],
+            "aoi_id": ["AFG.1.1"],
+            "aoi_type": ["admin2"],
+            "tree_cover_density": [30],
+            "carbon_gross_emissions_Mg_CO2e": [100.0],
+            "carbon_gross_removals_Mg_CO2e": [50.0],
         }
     )
     assert (
@@ -88,11 +88,11 @@ def test_qc_against_validation_source_with_fake_gee_repo():
     # Values diverge significantly from GEE validation (2x > 5% threshold) → fail
     result_df_diverged = pd.DataFrame(
         {
-            "aoi_id": ["AFG.1.1", "AFG.1.1"],
-            "aoi_type": ["admin2", "admin2"],
-            "tree_cover_density": [30, 30],
-            "carbontype": ["carbon_gross_emissions", "carbon_gross_removals"],
-            "value": [200.0, 100.0],
+            "aoi_id": ["AFG.1.1"],
+            "aoi_type": ["admin2"],
+            "tree_cover_density": [30],
+            "carbon_gross_emissions_Mg_CO2e": [200.0],
+            "carbon_gross_removals_Mg_CO2e": [100.0],
         }
     )
     assert (

--- a/pipelines/test/integration/tree_cover_loss/test_tcl_flow.py
+++ b/pipelines/test/integration/tree_cover_loss/test_tcl_flow.py
@@ -38,7 +38,7 @@ def test_tcl_flow_real_data(
             "v1.12", overwrite=True, bbox=test_geom.bounds
         )
 
-    assert "admin-tree-cover-loss.parquet" in result_uri
+    assert "admin-tree-cover-loss" in result_uri
     assert "v1.12" in result_uri
 
     # get the the saved df

--- a/pipelines/test/integration/tree_cover_loss/test_tcl_flow.py
+++ b/pipelines/test/integration/tree_cover_loss/test_tcl_flow.py
@@ -51,7 +51,7 @@ def test_tcl_flow_real_data(
         "is_intact_forest",
         "tree_cover_loss_driver",
         "is_primary_forest",
-        "natural_forest_class",
+        "natural_forests_class",
         "aoi_id",
         "aoi_type",
         "area_ha",
@@ -64,7 +64,7 @@ def test_tcl_flow_real_data(
     assert result_df["is_intact_forest"].dtype == bool
     assert result_df["tree_cover_loss_driver"].dtype == object
     assert result_df["is_primary_forest"].dtype == bool
-    assert result_df["natural_forest_class"].dtype == object
+    assert result_df["natural_forests_class"].dtype == object
     assert result_df.size == 37455
     mock_qc_write_results.assert_called_once()
 
@@ -132,7 +132,7 @@ def test_tcl_flow_with_new_contextual_layers(
         "is_intact_forest",
         "tree_cover_loss_driver",
         "is_primary_forest",
-        "natural_forest_class",
+        "natural_forests_class",
         "aoi_id",
         "aoi_type",
         "area_ha",
@@ -145,7 +145,7 @@ def test_tcl_flow_with_new_contextual_layers(
     assert result_df["is_intact_forest"].dtype == bool
     assert result_df["tree_cover_loss_driver"].dtype == object
     assert result_df["is_primary_forest"].dtype == bool
-    assert result_df["natural_forest_class"].dtype == object
+    assert result_df["natural_forests_class"].dtype == object
     assert result_df.size == 396
 
 
@@ -212,7 +212,7 @@ def test_tcl_flow_with_bbox(
         "is_intact_forest",
         "tree_cover_loss_driver",
         "is_primary_forest",
-        "natural_forest_class",
+        "natural_forests_class",
         "aoi_id",
         "aoi_type",
         "area_ha",
@@ -225,5 +225,5 @@ def test_tcl_flow_with_bbox(
     assert result_df["is_intact_forest"].dtype == bool
     assert result_df["tree_cover_loss_driver"].dtype == object
     assert result_df["is_primary_forest"].dtype == bool
-    assert result_df["natural_forest_class"].dtype == object
+    assert result_df["natural_forests_class"].dtype == object
     assert result_df.size == 99

--- a/pipelines/test/integration/tree_cover_loss/test_tcl_flow.py
+++ b/pipelines/test/integration/tree_cover_loss/test_tcl_flow.py
@@ -38,7 +38,7 @@ def test_tcl_flow_real_data(
             "v1.12", overwrite=True, bbox=test_geom.bounds
         )
 
-    assert "admin-tree-cover-loss_v20260512.parquet" in result_uri
+    assert "admin-tree-cover-loss_v20260424.parquet" in result_uri
     assert "v1.12" in result_uri
 
     # get the the saved df

--- a/pipelines/test/unit/tree_cover_loss/test_qc.py
+++ b/pipelines/test/unit/tree_cover_loss/test_qc.py
@@ -10,7 +10,7 @@ from pipelines.test.integration.tree_cover_loss.conftest import (
 from pipelines.tree_cover_loss import stages
 
 
-def _make_result_df(area_ha, canopy_cover, driver, natural_forest_class):
+def _make_result_df(area_ha, canopy_cover, driver, natural_forests_class):
     return pd.DataFrame(
         {
             "area_ha": area_ha,
@@ -18,7 +18,7 @@ def _make_result_df(area_ha, canopy_cover, driver, natural_forest_class):
             "canopy_cover": canopy_cover,
             "tree_cover_loss_driver": driver,
             "aoi_id": ["AFG.1.1", "AFG.1.1"],
-            "natural_forest_class": natural_forest_class,
+            "natural_forests_class": natural_forests_class,
         }
     )
 

--- a/pipelines/test/unit/tree_cover_loss/test_setup_compute.py
+++ b/pipelines/test/unit/tree_cover_loss/test_setup_compute.py
@@ -116,7 +116,7 @@ def test_setup_compute_groupby_schema_and_order():
         (2, "is_intact_forest", np.int16),
         (3, "tree_cover_loss_driver", np.int16),
         (4, "is_primary_forest", np.uint8),
-        (5, "natural_forest_class", np.uint8),
+        (5, "natural_forests_class", np.uint8),
         (6, "mangrove_stock_2000", np.uint8),
         (7, "tree_cover_gain_from_height", np.uint8),
         (8, "country", np.int16),

--- a/pipelines/tree_cover_loss/prefect_flows/tcl_flow.py
+++ b/pipelines/tree_cover_loss/prefect_flows/tcl_flow.py
@@ -38,7 +38,8 @@ def umd_tree_cover_loss_flow(
     Returns:
         The S3 URI for the saved parquet result.
     """
-    result_uri = f"s3://{ANALYTICS_BUCKET}/zonal-statistics/tcl/{version}/admin-tree-cover-loss.parquet"
+    # Should match the admin_results_uri in tree_cover_loss_analyzer.py
+    result_uri = f"s3://{ANALYTICS_BUCKET}/zonal-statistics/tcl/{version}/admin-tree-cover-loss_v20260424.parquet"
 
     if not overwrite and s3_uri_exists(result_uri):
         return result_uri

--- a/pipelines/tree_cover_loss/prefect_flows/tcl_flow.py
+++ b/pipelines/tree_cover_loss/prefect_flows/tcl_flow.py
@@ -39,7 +39,7 @@ def umd_tree_cover_loss_flow(
         The S3 URI for the saved parquet result.
     """
     # Should match the admin_results_uri in tree_cover_loss_analyzer.py
-    result_uri = f"s3://{ANALYTICS_BUCKET}/zonal-statistics/tcl/{version}/admin-tree-cover-loss_v20260512.parquet"
+    result_uri = f"s3://{ANALYTICS_BUCKET}/zonal-statistics/tcl/{version}/admin-tree-cover-loss_v20260424.parquet"
 
     if not overwrite and s3_uri_exists(result_uri):
         return result_uri

--- a/pipelines/tree_cover_loss/stages.py
+++ b/pipelines/tree_cover_loss/stages.py
@@ -314,6 +314,41 @@ def create_result_dataframe(result: xr.DataArray) -> pd.DataFrame:
     return df_pivoted
 
 
+# Temporarily pivot the canopy_cover column, so we can subtract, for each unique set
+# of ids and contextual columns, carbon_emissions_MgCO2e value for 50% canopy from
+# the 30% value, and the 75% value from the 50% value. This means our TCL carbon query
+# can then test for canopy_cover >= 30/50/75, rather than canopy_cover == 30/50/75.
+def unaggregate_carbon_by_canopy_cover(df: pd.DataFrame):
+    id_cols = ['aoi_id', 'aoi_type']
+    context_cols = [
+        'tree_cover_loss_year', 'is_intact_forest', 'tree_cover_loss_driver',
+        'is_primary_forest', 'natural_forest_class'
+    ]
+    group_cols = id_cols + context_cols
+    target_col = 'carbon_emissions_MgCO2e'
+
+    # Pivot the data to make subtraction easy. This aligns the canopy values side-by-side
+    # for every unique group
+    pivoted = df.pivot_table(index=group_cols, columns='canopy_cover', values=target_col).fillna(0)
+
+    # Do the actual difference calculation, so we can use canopy_cover >= 30/50/75,
+    # rather than canopy_cover == 30/50/75
+    pivoted[30] = pivoted[30] - pivoted[50]
+    pivoted[50] = pivoted[50] - pivoted[75]
+
+    # Convert the pivoted table back to long format with values 30/50/75.
+    updated_values = pivoted[[30, 50, 75]].stack().reset_index()
+    updated_values.columns = group_cols + ['canopy_cover', 'new_val']
+
+    # Merge with the original data frame, and take the new carbon value where calculated.
+    df = df.merge(updated_values, on=group_cols + ['canopy_cover'], how='left')
+    df[target_col] = df['new_val'].combine_first(df[target_col])
+
+    # Drop the helper column
+    df = df.drop(columns=['new_val'])
+    return df
+
+
 def postprocess_result(result: xr.DataArray) -> pd.DataFrame:
     result_df = create_result_dataframe(result)
     # convert year values (1-24) to actual years (2001-2024)
@@ -404,6 +439,8 @@ def postprocess_result(result: xr.DataArray) -> pd.DataFrame:
     final_df[value_cols] = final_df[value_cols].fillna(0)
 
     results_with_ids = rollup_by_gadm_and_convert_to_aoi(final_df, contextual_cols)
+
+    results_with_ids = unaggregate_carbon_by_canopy_cover(results_with_ids)
 
     return results_with_ids
 

--- a/pipelines/tree_cover_loss/stages.py
+++ b/pipelines/tree_cover_loss/stages.py
@@ -273,7 +273,7 @@ def setup_compute(
         ifl.rename("is_intact_forest"),
         drivers.rename("tree_cover_loss_driver"),
         primary_forests.rename("is_primary_forest"),
-        natural_forests.rename("natural_forest_class"),
+        natural_forests.rename("natural_forests_class"),
         mangrove.rename("mangrove_stock_2000"),
         height.rename("tree_cover_gain_from_height"),
         country.rename("country"),
@@ -322,7 +322,7 @@ def unaggregate_carbon_by_canopy_cover(df: pd.DataFrame):
     id_cols = ['aoi_id', 'aoi_type']
     context_cols = [
         'tree_cover_loss_year', 'is_intact_forest', 'tree_cover_loss_driver',
-        'is_primary_forest', 'natural_forest_class'
+        'is_primary_forest', 'natural_forests_class'
     ]
     group_cols = id_cols + context_cols
     target_col = 'carbon_emissions_MgCO2e'
@@ -380,13 +380,13 @@ def postprocess_result(result: xr.DataArray) -> pd.DataFrame:
     # convert primary forest to boolean
     result_df["is_primary_forest"] = result_df["is_primary_forest"].astype(bool)
 
-    natural_forest_class_to_label = {
+    natural_forests_class_to_label = {
         0: "Unknown",
         1: "Natural Forest",
         2: "Non-natural Forest",
     }
-    result_df["natural_forest_class"] = result_df["natural_forest_class"].map(
-        natural_forest_class_to_label
+    result_df["natural_forests_class"] = result_df["natural_forests_class"].map(
+        natural_forests_class_to_label
     )
 
     result_df["country"] = result_df["country"].map(numeric_to_alpha3)
@@ -400,7 +400,7 @@ def postprocess_result(result: xr.DataArray) -> pd.DataFrame:
         "is_intact_forest",
         "tree_cover_loss_driver",
         "is_primary_forest",
-        "natural_forest_class",
+        "natural_forests_class",
     ]
     gadm_cols = ["country", "region", "subregion"]
     groupby_cols = contextual_cols + gadm_cols
@@ -478,7 +478,7 @@ def qc_against_validation_source(
             ].area_ha.sum()
 
             sample_natural_forests_ha_total = sample_stats[
-                (sample_stats.natural_forest_class != "Unknown")
+                (sample_stats.natural_forests_class != "Unknown")
                 & (sample_stats.tree_cover_loss_year > 2020)
             ].area_ha.sum()
         else:


### PR DESCRIPTION
Adjust TCL pipeline post-processing to allow >= query for carbon

After calculating the 30/50/75% values for carbon emissions in TCL pipeline, then subtract 50% value from 30% value, and 75% value from 50% value. This allows the query for carbon to be canopy_cover >= 30/50/75%, rather than canopy_cover == 30/50/75%.

The parquet has already been adjusted in this way and saved as:

s3://lcl-analytics/zonal-statistics/tcl/v1.13/admin-tree-cover-loss_v20260424.parquet
