### PR TITLE
fix webhook

### DIFF
--- a/pipelines/disturbance/prefect_flows/dist_flow.py
+++ b/pipelines/disturbance/prefect_flows/dist_flow.py
@@ -52,6 +52,9 @@ def dist_alerts_flow(dist_version=None, overwrite=False, is_latest=False) -> lis
     logger = get_run_logger()
     result_uris = []
 
+    is_latest = str(is_latest).lower() == "true"
+    overwrite = str(overwrite).lower() == "true"
+
     if dist_version is None:
         is_latest = True
         dist_version = get_new_dist_version()

--- a/pipelines/disturbance/prefect_flows/dist_flow.py
+++ b/pipelines/disturbance/prefect_flows/dist_flow.py
@@ -52,9 +52,6 @@ def dist_alerts_flow(dist_version=None, overwrite=False, is_latest=False) -> lis
     logger = get_run_logger()
     result_uris = []
 
-    is_latest = str(is_latest).lower() == "true"
-    overwrite = str(overwrite).lower() == "true"
-
     if dist_version is None:
         is_latest = True
         dist_version = get_new_dist_version()

--- a/pipelines/run_updates.py
+++ b/pipelines/run_updates.py
@@ -83,7 +83,8 @@ update_flows = {
     name="GNW zonal stats update",
     log_prints=True,
     description=(
-        "Update the zonal statistics by GADM areas (admin levels 0, 1 and 2). Two flows are available: "
+        "This is the entry point to run updates via Prefect Cloud UI or CLI to update zonal statistics for various datasets for GADM areas."
+        "Two flows are available currently: "
         "-'dist_update' will just run an update on DIST alerts, and is the default for backward compatibility"
         "-'tcl_update' will run tree_cover_loss and carbon_flux flows to provide all necessary updates for TCL."
     ),
@@ -97,6 +98,10 @@ def run_updates(
     logger = get_run_logger()
     dask_client = None
     result_uris = []
+
+    # when called from Prefect webhook, the booleans flags are passed as strings, so we need to convert them to booleans
+    is_latest = str(is_latest).lower() == "true"
+    overwrite = str(overwrite).lower() == "true"
 
     try:
         dask_client = create_cluster()

--- a/terraform/prefect.tf
+++ b/terraform/prefect.tf
@@ -114,6 +114,7 @@ resource "prefect_deployment" "gnw_zonal_stats_update" {
   flow_id        = prefect_flow.gnw_zonal_stats_update.id
   path           = "/app"
   entrypoint     = "pipelines/run_updates.py:run_updates"
+  enforce_parameter_schema = false
 
   job_variables = jsonencode({
     image = var.pipelines_image


### PR DESCRIPTION
This fixes a regression issue introduced when we added the ability to trigger analysis pipeline updates from the Prefect Cloud UI. The issue is blocking data-pump webhook triggers and we're having to manually trigger it from the UI weekly.
