### PR TITLE
Switch to the fixed IFL admin-tree-cover-loss.parquet in production

### DIFF
--- a/api/app/domain/analyzers/tree_cover_loss_analyzer.py
+++ b/api/app/domain/analyzers/tree_cover_loss_analyzer.py
@@ -44,7 +44,7 @@ INPUT_URIS: Dict[Environment, Dict[str, str]] = {
             ]
         },
         # Should match result_uri in tcl_flow.py in pipelines.
-        "admin_results_uri": "s3://lcl-analytics/zonal-statistics/tcl/v1.13/admin-tree-cover-loss_v20260424.parquet",
+        "admin_results_uri": "s3://lcl-analytics/zonal-statistics/tcl/v1.13/admin-tree-cover-loss_v20260518.parquet",
     },
 }
 

--- a/pipelines/test/integration/tree_cover_loss/test_tcl_flow.py
+++ b/pipelines/test/integration/tree_cover_loss/test_tcl_flow.py
@@ -38,7 +38,7 @@ def test_tcl_flow_real_data(
             "v1.12", overwrite=True, bbox=test_geom.bounds
         )
 
-    assert "admin-tree-cover-loss_v20260424.parquet" in result_uri
+    assert "admin-tree-cover-loss_v20260518.parquet" in result_uri
     assert "v1.12" in result_uri
 
     # get the the saved df

--- a/pipelines/tree_cover_loss/prefect_flows/tcl_flow.py
+++ b/pipelines/tree_cover_loss/prefect_flows/tcl_flow.py
@@ -39,7 +39,7 @@ def umd_tree_cover_loss_flow(
         The S3 URI for the saved parquet result.
     """
     # Should match the admin_results_uri in tree_cover_loss_analyzer.py
-    result_uri = f"s3://{ANALYTICS_BUCKET}/zonal-statistics/tcl/{version}/admin-tree-cover-loss_v20260424.parquet"
+    result_uri = f"s3://{ANALYTICS_BUCKET}/zonal-statistics/tcl/{version}/admin-tree-cover-loss_v20260518.parquet"
 
     if not overwrite and s3_uri_exists(result_uri):
         return result_uri


### PR DESCRIPTION
I generated the new parquet running that pipeline with the corrected IFL zarr last week, and did a comparison script, to show that it is the same as the old parquet, except for fixed IFL values. I copied that new parquet into
s3://lcl-analytics/zonal-statistics/tcl/v1.13/admin-tree-cover-loss_v20260518.parquet. So this change is to atomically switch over to using that parquet for the analyzer.
