### PR TITLE
Extend the date range for dist alerts to 2030/1/1

### DIFF
--- a/api/app/analysis/dist_alerts/analysis.py
+++ b/api/app/analysis/dist_alerts/analysis.py
@@ -104,7 +104,7 @@ async def zonal_statistics(
     ).band_data.reindex_like(dist_alerts, method="nearest", tolerance=1e-5)
 
     groupby_layers = [dist_alerts.alert_date, dist_alerts.confidence]
-    expected_groups = [np.arange(731, 2000), [1, 2, 3]]
+    expected_groups = [np.arange(731, 2365), [1, 2, 3]]  # Dates (2023/1/1 to 2027/6/23) and confidence
     if intersection == "natural_lands":
         natural_lands = read_zarr_clipped_to_geojson(
             input_uris["natural_lands_zarr_uri"],

--- a/api/app/analysis/dist_alerts/analysis.py
+++ b/api/app/analysis/dist_alerts/analysis.py
@@ -104,7 +104,7 @@ async def zonal_statistics(
     ).band_data.reindex_like(dist_alerts, method="nearest", tolerance=1e-5)
 
     groupby_layers = [dist_alerts.alert_date, dist_alerts.confidence]
-    expected_groups = [np.arange(731, 2365), [1, 2, 3]]  # Dates (2023/1/1 to 2027/6/23) and confidence
+    expected_groups = [np.arange(731, 3288), [1, 2, 3]]  # Dates (2023/1/1 to 2030/1/1) and confidence
     if intersection == "natural_lands":
         natural_lands = read_zarr_clipped_to_geojson(
             input_uris["natural_lands_zarr_uri"],

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts.py
@@ -18,7 +18,7 @@ def dist_alerts_area(dist_zarr_uri: str, dist_version: str, overwrite=False):
         np.arange(999),  # country ISO codes
         np.arange(86),  # region codes
         np.arange(854),  # subregion codes
-        np.arange(731, 2365),  # dates values, 2023/1/1 to 2027/6/23
+        np.arange(731, 3288),  # dates values, 2023/1/1 to 2030/1/1
         [1, 2, 3],  # confidence values
     )
 

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts.py
@@ -18,7 +18,7 @@ def dist_alerts_area(dist_zarr_uri: str, dist_version: str, overwrite=False):
         np.arange(999),  # country ISO codes
         np.arange(86),  # region codes
         np.arange(854),  # subregion codes
-        np.arange(731, 2000),  # dates values
+        np.arange(731, 2365),  # dates values, 2023/1/1 to 2027/6/23
         [1, 2, 3],  # confidence values
     )
 

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_drivers.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_drivers.py
@@ -27,7 +27,7 @@ def dist_alerts_by_drivers_area(dist_zarr_uri: str, dist_version: str, overwrite
         np.arange(86),  # region codes
         np.arange(854),  # subregion codes
         np.arange(5),  # driver categories
-        np.arange(731, 2000),  # dates values
+        np.arange(731, 2365),  # dates values, 2023/1/1 to 2027/6/23
         [1, 2, 3],  # confidence values
     )
     datasets = dist_common_tasks.load_data.with_options(

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_drivers.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_drivers.py
@@ -27,7 +27,7 @@ def dist_alerts_by_drivers_area(dist_zarr_uri: str, dist_version: str, overwrite
         np.arange(86),  # region codes
         np.arange(854),  # subregion codes
         np.arange(5),  # driver categories
-        np.arange(731, 2365),  # dates values, 2023/1/1 to 2027/6/23
+        np.arange(731, 3288),  # dates values, 2023/1/1 to 2030/1/1
         [1, 2, 3],  # confidence values
     )
     datasets = dist_common_tasks.load_data.with_options(

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_grasslands.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_grasslands.py
@@ -21,7 +21,7 @@ def dist_alerts_by_grasslands_area(
         np.arange(86),  # region codes
         np.arange(854),  # subregion codes
         [0, 1],  # grasslands boolean
-        np.arange(731, 2000),  # dates values
+        np.arange(731, 2365),  # dates values, 2023/1/1 to 2027/6/23
         [1, 2, 3],  # confidence values
     )
     datasets = dist_common_tasks.load_data.with_options(

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_grasslands.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_grasslands.py
@@ -21,7 +21,7 @@ def dist_alerts_by_grasslands_area(
         np.arange(86),  # region codes
         np.arange(854),  # subregion codes
         [0, 1],  # grasslands boolean
-        np.arange(731, 2365),  # dates values, 2023/1/1 to 2027/6/23
+        np.arange(731, 3288),  # dates values, 2023/1/1 to 2030/1/1
         [1, 2, 3],  # confidence values
     )
     datasets = dist_common_tasks.load_data.with_options(

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_land_cover.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_land_cover.py
@@ -33,7 +33,7 @@ def dist_alerts_by_land_cover_area(
         np.arange(86),  # region codes
         np.arange(854),  # subregion codes
         np.arange(9),  # land cover classes
-        np.arange(731, 2365),  # dates values, 2023/1/1 to 2027/6/23
+        np.arange(731, 3288),  # dates values, 2023/1/1 to 2030/1/1
         [1, 2, 3],  # confidence values
     )
     datasets = dist_common_tasks.load_data.with_options(

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_land_cover.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_land_cover.py
@@ -33,7 +33,7 @@ def dist_alerts_by_land_cover_area(
         np.arange(86),  # region codes
         np.arange(854),  # subregion codes
         np.arange(9),  # land cover classes
-        np.arange(731, 2000),  # dates values
+        np.arange(731, 2365),  # dates values, 2023/1/1 to 2027/6/23
         [1, 2, 3],  # confidence values
     )
     datasets = dist_common_tasks.load_data.with_options(

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_natural_lands.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_natural_lands.py
@@ -44,7 +44,7 @@ def dist_alerts_by_natural_lands_area(
         np.arange(86),  # region codes
         np.arange(854),  # subregion codes
         np.arange(22),  # natural lands categories
-        np.arange(731, 2365),  # dates values, 2023/1/1 to 2027/6/23
+        np.arange(731, 3288),  # dates values, 2023/1/1 to 2030/1/1
         [1, 2, 3],  # confidence values
     )
     datasets = dist_common_tasks.load_data.with_options(

--- a/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_natural_lands.py
+++ b/pipelines/disturbance/prefect_flows/gadm_dist_alerts_by_natural_lands.py
@@ -44,7 +44,7 @@ def dist_alerts_by_natural_lands_area(
         np.arange(86),  # region codes
         np.arange(854),  # subregion codes
         np.arange(22),  # natural lands categories
-        np.arange(731, 2000),  # dates values
+        np.arange(731, 2365),  # dates values, 2023/1/1 to 2027/6/23
         [1, 2, 3],  # confidence values
     )
     datasets = dist_common_tasks.load_data.with_options(


### PR DESCRIPTION
Extend the date range for dist alerts to 2027/6/23

We were about to run out, since end point was 2026/6/23 (2000 days from 2020/12/31).
