### PR TITLE
Integration tests for integrated alerts

### DIFF
--- a/pipelines/integrated_alerts/stages.py
+++ b/pipelines/integrated_alerts/stages.py
@@ -48,6 +48,7 @@ def load_data(
     pixel_area = _load_zarr(pixel_area_10m_zarr_uri).reindex_like(
         alerts, method="nearest", tolerance=1e-5
     ).astype(np.float64)
+    # Convert pixel area from square meters to hectares.
     pixel_area_aligned = (
         xr.align(alerts, pixel_area, join="left")[1].band_data / 10000
     )

--- a/pipelines/integrated_alerts/stages.py
+++ b/pipelines/integrated_alerts/stages.py
@@ -48,7 +48,9 @@ def load_data(
     pixel_area = _load_zarr(pixel_area_10m_zarr_uri).reindex_like(
         alerts, method="nearest", tolerance=1e-5
     ).astype(np.float64)
-    pixel_area_aligned = xr.align(alerts, pixel_area, join="left")[1].band_data
+    pixel_area_aligned = (
+        xr.align(alerts, pixel_area, join="left")[1].band_data / 10000
+    )
 
     if contextual_uri is not None:
         contextual_layer = _load_zarr(contextual_uri).reindex_like(

--- a/pipelines/test/integration/integrated_alerts/conftest.py
+++ b/pipelines/test/integration/integrated_alerts/conftest.py
@@ -1,0 +1,92 @@
+import pytest
+import numpy as np
+import xarray as xr
+import dask.array as da
+
+
+@pytest.fixture
+def expected_groups():
+    return (
+        # Match expected groups to minimal data values
+        [12],  # Country values in minimal data
+        [7],  # Region values
+        [124, 125],  # Subregion values
+        [2923, 2954, 3000], # Alert date values in minimal data (days since 2014-12-31):
+        [2, 3],  # Confidence values in minimal data
+    )
+
+
+@pytest.fixture
+def integrated_alerts_ds():
+    confidence_data = da.array([[[3, 2], [2, 3]]], dtype=np.int16)
+    alert_date_data = da.array([[[2954, 2923], [2923, 3000]]], dtype=np.int16)
+    integrated_alerts = xr.Dataset(
+        data_vars={
+            "confidence": (("band", "y", "x"), confidence_data),
+            "alert_date": (("band", "y", "x"), alert_date_data),
+        },
+        coords={
+            "band": ("band", [1], {}),
+            "y": ("y", [60.0, 59.99975], {}),
+            "x": ("x", [-180.0, -179.99975], {}),
+            "spatial_ref": ((), 0, {}),
+        },
+        attrs={},
+    )
+
+    return integrated_alerts
+
+
+@pytest.fixture
+def country_ds():
+    country = xr.Dataset(
+        data_vars={
+            "band_data": (
+                ("band", "y", "x"),
+                da.array([[[12, 12], [12, 12]]], dtype=np.uint16),
+            )
+        }
+    )
+
+    return country
+
+
+@pytest.fixture
+def region_ds():
+    region = xr.Dataset(
+        data_vars={
+            "band_data": (
+                ("band", "y", "x"),
+                da.array([[[7, 7], [7, 7]]], dtype=np.uint16),
+            )
+        }
+    )
+    return region
+
+
+@pytest.fixture
+def subregion_ds():
+    subregion = xr.Dataset(
+        data_vars={
+            "band_data": (
+                ("band", "y", "x"),
+                da.array([[[124, 124], [124, 125]]], dtype=np.uint16),
+            )
+        }
+    )
+
+    return subregion
+
+
+@pytest.fixture
+def pixel_area_ds():
+    pixel_area = xr.Dataset(
+        data_vars={
+            "band_data": (
+                ("band", "y", "x"),
+                da.array([[[750.0, 750.0], [750.0, 750.0]]], dtype=np.float32),
+            )
+        },
+    )
+
+    return pixel_area

--- a/pipelines/test/integration/integrated_alerts/conftest.py
+++ b/pipelines/test/integration/integrated_alerts/conftest.py
@@ -80,11 +80,14 @@ def subregion_ds():
 
 @pytest.fixture
 def pixel_area_ds():
+
     pixel_area = xr.Dataset(
         data_vars={
             "band_data": (
                 ("band", "y", "x"),
-                da.array([[[750.0, 750.0], [750.0, 750.0]]], dtype=np.float32),
+                da.array(
+                    [[[25000.0, 25000.0], [25000.0, 25000.0]]], dtype=np.float32
+                ),
             )
         },
     )

--- a/pipelines/test/integration/integrated_alerts/conftest.py
+++ b/pipelines/test/integration/integrated_alerts/conftest.py
@@ -8,7 +8,7 @@ import dask.array as da
 def expected_groups():
     return (
         # Match expected groups to minimal data values
-        [12],  # Country values in minimal data
+        [76],  # Country values in minimal data
         [7],  # Region values
         [124, 125],  # Subregion values
         [2923, 2954, 3000], # Alert date values in minimal data (days since 2014-12-31):
@@ -43,7 +43,7 @@ def country_ds():
         data_vars={
             "band_data": (
                 ("band", "y", "x"),
-                da.array([[[12, 12], [12, 12]]], dtype=np.uint16),
+                da.array([[[76, 76], [76, 76]]], dtype=np.uint16),
             )
         }
     )
@@ -90,3 +90,84 @@ def pixel_area_ds():
     )
 
     return pixel_area
+
+
+@pytest.fixture
+def multi_admin_alerts_ds():
+    """Alerts spanning BRA and IDN with uniform confidence and date so
+     the rollup exercised is purely spatial."""
+    confidence_data = da.array([[[3, 3], [3, 3]]], dtype=np.int16)
+    alert_date_data = da.array([[[2923, 2923], [2923, 2923]]], dtype=np.int16)
+    integrated_alerts = xr.Dataset(
+        data_vars={
+            "confidence": (("band", "y", "x"), confidence_data),
+            "alert_date": (("band", "y", "x"), alert_date_data),
+        },
+        coords={
+            "band": ("band", [1], {}),
+            "y": ("y", [60.0, 59.99975], {}),
+            "x": ("x", [-180.0, -179.99975], {}),
+            "spatial_ref": ((), 0, {}),
+        },
+        attrs={},
+    )
+
+    return integrated_alerts
+
+
+@pytest.fixture
+def multi_country_ds():
+    # 76 -> "BRA", 360 -> "IDN"
+    country = xr.Dataset(
+        data_vars={
+            "band_data": (
+                ("band", "y", "x"),
+                da.array([[[76, 76], [360, 360]]], dtype=np.uint16),
+            )
+        }
+    )
+
+    return country
+
+
+@pytest.fixture
+def multi_region_ds():
+    region = xr.Dataset(
+        data_vars={
+            "band_data": (
+                ("band", "y", "x"),
+                da.array([[[1, 2], [1, 1]]], dtype=np.uint16),
+            )
+        }
+    )
+
+    return region
+
+
+@pytest.fixture
+def multi_subregion_ds():
+    subregion = xr.Dataset(
+        data_vars={
+            "band_data": (
+                ("band", "y", "x"),
+                da.array([[[10, 20], [30, 30]]], dtype=np.uint16),
+            )
+        }
+    )
+
+    return subregion
+
+
+@pytest.fixture
+def ocean_country_ds():
+    # ISO -> 0 means should be dropped (no country)
+    country = xr.Dataset(
+        data_vars={
+            "band_data": (
+                ("band", "y", "x"),
+                da.array([[[0, 0], [0, 0]]], dtype=np.uint16),
+            )
+        }
+    )
+
+    return country

--- a/pipelines/test/integration/integrated_alerts/conftest.py
+++ b/pipelines/test/integration/integrated_alerts/conftest.py
@@ -11,7 +11,7 @@ def expected_groups():
         [76],  # Country values in minimal data
         [7],  # Region values
         [124, 125],  # Subregion values
-        [2923, 2954, 3000], # Alert date values in minimal data (days since 2014-12-31):
+        [2923, 2954, 3000],  # Alert date values in minimal data (days since 2014-12-31):
         [2, 3],  # Confidence values in minimal data
     )
 

--- a/pipelines/test/integration/integrated_alerts/test_gadm_integrated_alerts.py
+++ b/pipelines/test/integration/integrated_alerts/test_gadm_integrated_alerts.py
@@ -1,0 +1,124 @@
+import datetime
+from unittest.mock import patch
+
+import pytest
+from pandera.pandas import Check, Column, DataFrameSchema
+from prefect.testing.utilities import prefect_test_harness
+
+from pipelines.integrated_alerts.prefect_flows.gadm_integrated_alerts import (
+    integrated_alerts_area,
+)
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+@patch("pipelines.prefect_flows.common_stages._save_parquet")
+@patch("pipelines.integrated_alerts.stages._load_zarr")
+def test_gadm_integrated_alerts_happy_path(
+    mock_load_zarr,
+    mock_save_parquet,
+    integrated_alerts_ds,
+    country_ds,
+    region_ds,
+    subregion_ds,
+    pixel_area_ds,
+):
+    """Test full workflow with in-memory dependencies"""
+
+    mock_load_zarr.side_effect = [
+        integrated_alerts_ds,
+        country_ds,
+        region_ds,
+        subregion_ds,
+        pixel_area_ds,
+    ]
+
+    with prefect_test_harness():
+        result_uri = integrated_alerts_area(
+            integrated_alerts_zarr_uri="s3://dummy_zarr_uri",
+            version="test_v1",
+        )
+
+    assert (
+        result_uri
+        == "s3://lcl-analytics/zonal-statistics/integrated-alerts/test_v1/admin-integrated-alerts.parquet"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+@patch("pipelines.prefect_flows.common_stages._save_parquet")
+@patch("pipelines.integrated_alerts.stages._load_zarr")
+def test_gadm_integrated_alerts_result(
+    mock_load_zarr,
+    mock_save_parquet,
+    integrated_alerts_ds,
+    country_ds,
+    region_ds,
+    subregion_ds,
+    pixel_area_ds,
+):
+    alert_schema = DataFrameSchema(
+        name="GADM Integrated Alerts",
+        columns={
+            "aoi_id": Column(str, Check.ne("")),
+            "aoi_type": Column(str, Check.eq("admin")),
+            "alert_date": Column(
+                datetime.date,
+                checks=[
+                    Check.greater_than_or_equal_to(
+                        datetime.date.fromisoformat("2023-01-01")
+                    ),
+                    Check.less_than_or_equal_to(
+                        datetime.date.fromisoformat("2023-12-31")
+                    ),
+                ],
+            ),
+            "alert_confidence": Column(str, Check.isin(["low", "high"])),
+            "area_ha": Column("float64", Check.isin([750.0, 1500.0])),
+        },
+        unique=[
+            "aoi_id",
+            "alert_date",
+            "alert_confidence",
+        ],
+        checks=Check(
+            lambda df: (
+                df.groupby(["aoi_id", "alert_date"])["alert_confidence"].transform(
+                    "nunique"
+                )
+                == 1
+            ),
+            name="two_confidence_per_group",
+            error="Each aoi/date must have exactly 1 confidence level",
+        ),
+    )
+
+    mock_load_zarr.side_effect = [
+        integrated_alerts_ds,
+        country_ds,
+        region_ds,
+        subregion_ds,
+        pixel_area_ds,
+    ]
+
+    with prefect_test_harness():
+        integrated_alerts_area(
+            integrated_alerts_zarr_uri="s3://dummy_zarr_uri",
+            version="test_v1",
+        )
+
+    # Verify
+    result = mock_save_parquet.call_args[0][0]
+    print(f"\nGADM integrated alerts result:\n{result}")
+    alert_schema.validate(result)
+
+    # ensure that the result uses the rolled up aoi_id
+    assert set(result["aoi_id"]) == {"DZA", "DZA.7", "DZA.7.124", "DZA.7.125"}
+    assert (result["aoi_type"] == "admin").all()
+    assert not {"country", "region", "subregion"} & set(result.columns)
+
+    # every admin level totals the same area (4 px x 750)
+    country_total = result[~result.aoi_id.str.contains(r"\.")]["area_ha"].sum()
+    subregion_total = result[result.aoi_id.str.count(r"\.") == 2]["area_ha"].sum()
+    assert country_total == subregion_total == 3000.0

--- a/pipelines/test/integration/integrated_alerts/test_gadm_integrated_alerts.py
+++ b/pipelines/test/integration/integrated_alerts/test_gadm_integrated_alerts.py
@@ -114,7 +114,7 @@ def test_gadm_integrated_alerts_result(
     alert_schema.validate(result)
 
     # ensure that the result uses the rolled up aoi_id
-    assert set(result["aoi_id"]) == {"DZA", "DZA.7", "DZA.7.124", "DZA.7.125"}
+    assert set(result["aoi_id"]) == {"BRA", "BRA.7", "BRA.7.124", "BRA.7.125"}
     assert (result["aoi_type"] == "admin").all()
     assert not {"country", "region", "subregion"} & set(result.columns)
 
@@ -122,3 +122,116 @@ def test_gadm_integrated_alerts_result(
     country_total = result[~result.aoi_id.str.contains(r"\.")]["area_ha"].sum()
     subregion_total = result[result.aoi_id.str.count(r"\.") == 2]["area_ha"].sum()
     assert country_total == subregion_total == 3000.0
+
+    # verify dates and confidence levels
+    bra_by_date = dict(
+        zip(
+            result.loc[result.aoi_id == "BRA", "alert_date"],
+            result.loc[result.aoi_id == "BRA", "alert_confidence"],
+        )
+    )
+    assert bra_by_date[datetime.date(2023, 1, 1)] == "low"  # day 2923
+    assert bra_by_date[datetime.date(2023, 2, 1)] == "high"  # day 2954
+    assert bra_by_date[datetime.date(2023, 3, 19)] == "high"  # day 3000
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+@patch("pipelines.prefect_flows.common_stages._save_parquet")
+@patch("pipelines.integrated_alerts.stages._load_zarr")
+def test_gadm_integrated_alerts_multi_admin_rollup(
+    mock_load_zarr,
+    mock_save_parquet,
+    multi_admin_alerts_ds,
+    multi_country_ds,
+    multi_region_ds,
+    multi_subregion_ds,
+    pixel_area_ds,
+):
+    """Alerts across two countries with multiple regions/subregions roll up to
+    every admin level, and area is conserved within each country across adm levels."""
+    mock_load_zarr.side_effect = [
+        multi_admin_alerts_ds,
+        multi_country_ds,
+        multi_region_ds,
+        multi_subregion_ds,
+        pixel_area_ds,
+    ]
+
+    with prefect_test_harness():
+        integrated_alerts_area(
+            integrated_alerts_zarr_uri="s3://dummy_zarr_uri",
+            version="test_v1",
+        )
+
+    result = mock_save_parquet.call_args[0][0]
+
+    # all three admin levels are emitted for both countries
+    assert set(result["aoi_id"]) == {
+        "BRA",
+        "IDN",
+        "BRA.1",
+        "BRA.2",
+        "IDN.1",
+        "BRA.1.10",
+        "BRA.2.20",
+        "IDN.1.30",
+    }
+    assert (result["aoi_type"] == "admin").all()
+
+    # verify area is correct per country across adm levels
+    # BRA = 2px, IDN = 2px, each px = 750ha
+    for country, n_pixels in (("BRA", 2), ("IDN", 2)):
+        prefix = f"{country}."
+        country_total = result.loc[result.aoi_id == country, "area_ha"].sum()
+        region_total = result.loc[
+            result.aoi_id.str.startswith(prefix)
+            & (result.aoi_id.str.count(r"\.") == 1),
+            "area_ha",
+        ].sum()
+        subregion_total = result.loc[
+            result.aoi_id.str.startswith(prefix)
+            & (result.aoi_id.str.count(r"\.") == 2),
+            "area_ha",
+        ].sum()
+        assert (
+            country_total == region_total == subregion_total == n_pixels * 750.0
+        )
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+@patch("pipelines.prefect_flows.common_stages._save_parquet")
+@patch("pipelines.integrated_alerts.stages._load_zarr")
+def test_gadm_integrated_alerts_filters_pixels_with_no_country(
+    mock_load_zarr,
+    mock_save_parquet,
+    integrated_alerts_ds,
+    ocean_country_ds,
+    region_ds,
+    subregion_ds,
+    pixel_area_ds,
+):
+    """Pixels with no iso are dropped. When nothing remains, the flow still
+    completes and saves an empty, correctly-shaped result"""
+    mock_load_zarr.side_effect = [
+        integrated_alerts_ds,
+        ocean_country_ds,
+        region_ds,
+        subregion_ds,
+        pixel_area_ds,
+    ]
+
+    with prefect_test_harness():
+        result_uri = integrated_alerts_area(
+            integrated_alerts_zarr_uri="s3://dummy_zarr_uri",
+            version="test_v1",
+        )
+
+    assert result_uri.endswith("admin-integrated-alerts.parquet")
+    mock_save_parquet.assert_called_once()
+
+    result = mock_save_parquet.call_args[0][0]
+    assert len(result) == 0
+    assert {"aoi_id", "aoi_type"}.issubset(result.columns)
+    assert not {"country", "region", "subregion"} & set(result.columns)

--- a/pipelines/test/integration/integrated_alerts/test_gadm_integrated_alerts.py
+++ b/pipelines/test/integration/integrated_alerts/test_gadm_integrated_alerts.py
@@ -75,7 +75,7 @@ def test_gadm_integrated_alerts_result(
                 ],
             ),
             "alert_confidence": Column(str, Check.isin(["low", "high"])),
-            "area_ha": Column("float64", Check.isin([750.0, 1500.0])),
+            "area_ha": Column("float64", Check.isin([2.5, 5.0])),
         },
         unique=[
             "aoi_id",
@@ -118,10 +118,10 @@ def test_gadm_integrated_alerts_result(
     assert (result["aoi_type"] == "admin").all()
     assert not {"country", "region", "subregion"} & set(result.columns)
 
-    # every admin level totals the same area (4 px x 750)
+    # every admin level totals the same area (4 px x 2.5 ha)
     country_total = result[~result.aoi_id.str.contains(r"\.")]["area_ha"].sum()
     subregion_total = result[result.aoi_id.str.count(r"\.") == 2]["area_ha"].sum()
-    assert country_total == subregion_total == 3000.0
+    assert country_total == subregion_total == 10.0
 
     # verify dates and confidence levels
     bra_by_date = dict(
@@ -180,7 +180,7 @@ def test_gadm_integrated_alerts_multi_admin_rollup(
     assert (result["aoi_type"] == "admin").all()
 
     # verify area is correct per country across adm levels
-    # BRA = 2px, IDN = 2px, each px = 750ha
+    # BRA = 2px, IDN = 2px, each px = 2.5 ha
     for country, n_pixels in (("BRA", 2), ("IDN", 2)):
         prefix = f"{country}."
         country_total = result.loc[result.aoi_id == country, "area_ha"].sum()
@@ -195,7 +195,7 @@ def test_gadm_integrated_alerts_multi_admin_rollup(
             "area_ha",
         ].sum()
         assert (
-            country_total == region_total == subregion_total == n_pixels * 750.0
+            country_total == region_total == subregion_total == n_pixels * 2.5
         )
 
 


### PR DESCRIPTION
Integration tests for integrated alerts:
- `test_gadm_integrated_alerts_happy_path` (based off of DIST alerts)
- `test_gadm_integrated_alerts_result` (based off of DIST alerts)
- `test_gadm_integrated_alerts_multi_admin_rollup` (tests the new admin rollup)
- `test_gadm_integrated_alerts_filters_pixels_with_no_country` (tests stray pixels with no iso)

I also switched the flow from meters to hectares