### PR TITLE
Run the integrated_alerts_flow when an intdist-updated-event webhook is received

### DIFF
--- a/terraform/prefect.tf
+++ b/terraform/prefect.tf
@@ -213,6 +213,52 @@ resource "prefect_automation" "run_pipelines_on_dist_update" {
 }
 
 
+resource "prefect_webhook" "intdist_update_event" {
+  name        = "intdist-updated-event${local.name_suffix}"
+  description = "Fire an event when a new integrated (intdist) alerts version is published."
+  enabled     = true
+  template = jsonencode({
+    event = "intdist_updated${local.name_suffix}"
+    payload = {
+      dataset = "{{body.dataset}}"
+      version = "{{body.version}}"
+      is_latest = "{{body.is_latest}}"
+    }
+    resource = {
+      "prefect.resource.id"   = "{{body.dataset}}/{{ body.version }}"
+      "prefect.resource.name" = "Integrated Alerts update for v{{ body.version }}"
+    }
+  })
+}
+
+resource "prefect_automation" "run_pipelines_on_intdist_update" {
+  name    = "run-gnw-zonal-stats-on-intdist-update${local.name_suffix}"
+  enabled = terraform.workspace == "default"
+
+  trigger = {
+    event = {
+      posture   = "Reactive"
+      expect    = ["intdist_updated${local.name_suffix}"]
+      threshold = 1
+      within    = 0
+    }
+  }
+  actions = [
+    {
+      type          = "run-deployment"
+      source        = "selected"
+      deployment_id = prefect_deployment.gnw_zonal_stats_update.id
+      parameters    = jsonencode({
+        version   = "{{ event.payload.version }}"
+        is_latest = "{{ event.payload.is_latest }}"
+        flow_name = "integrated_alerts_update"
+      })
+      job_variables = jsonencode({})
+    },
+  ]
+}
+
+
 # taken from https://github.com/PrefectHQ/terraform-prefect-ecs-worker/tree/main/examples/ecs-worker
 module "prefect_vpc" {
   source  = "terraform-aws-modules/vpc/aws"


### PR DESCRIPTION
Run the integrated_alerts_flow when an intdist-updated-event webhook is received

This terraform is completely in analogy with the code to handle the dist-updated-event webhook.

I have a parallel change to the datapump that sends the intdist-updated-event webhook when a new intdist version is created on Sunday or the next following day that creates a version.
