### PR TITLE
Record latest version of int alerts when is_latest flag is set

### DIFF
--- a/pipelines/integrated_alerts/prefect_flows/integrated_alerts_flow.py
+++ b/pipelines/integrated_alerts/prefect_flows/integrated_alerts_flow.py
@@ -1,11 +1,13 @@
 import logging
 
+import boto3
 from prefect import flow, task
 from prefect.logging import get_run_logger
 
 from pipelines.integrated_alerts.prefect_flows.gadm_integrated_alerts import integrated_alerts_area
 from pipelines.disturbance.check_for_new_alerts import get_latest_version
 from pipelines.integrated_alerts.create_zarr import create_zarr
+from pipelines.globals import ANALYTICS_BUCKET
 
 logging.getLogger("distributed.client").setLevel(logging.ERROR)
 
@@ -20,17 +22,28 @@ def create_zarr_task(dist_version: str, overwrite=False) -> str:
     zarr_uri = create_zarr(dist_version, overwrite=overwrite)
     return zarr_uri
 
+@task
+def write_int_latest_version(version) -> None:
+    s3_client = boto3.client("s3")
+    s3_client.put_object(
+        Bucket=ANALYTICS_BUCKET,
+        Key="zonal-statistics/integrated-alerts/latest",
+        Body=version.encode("utf-8"),
+        ContentType="text/plain",
+    )
+
 
 @flow(
     name="Create int-Dist zarr",
     log_prints=True,
     description="Create zarr from tiles of one version of the integrated disturbance alerts dataset",
 )
-def integrated_alerts_zarr_flow(version=None, overwrite=False) -> list[str]:
+def integrated_alerts_zarr_flow(version=None, overwrite=False, is_latest=False) -> list[str]:
     logger = get_run_logger()
     result_uris = []
 
     if version is None:
+        is_latest = True
         version = get_new_integrated_alerts_version()
         logger.info(f"Latest int-dist version: {version}")
 
@@ -41,5 +54,8 @@ def integrated_alerts_zarr_flow(version=None, overwrite=False) -> list[str]:
         integrated_alerts_zarr_uri, version, overwrite=overwrite
     )
     result_uris.append(gadm_dist_result)
+
+    if is_latest:
+        write_int_latest_version(version)
 
     return result_uris

--- a/pipelines/run_updates.py
+++ b/pipelines/run_updates.py
@@ -73,7 +73,9 @@ def run_tcl_update(version, overwrite=False, is_latest=False) -> list[str]:
 def run_integrated_alerts_update(version, overwrite=False, is_latest=False) -> list[str]:
     result_uris = []
 
-    result = integrated_alerts_flow.integrated_alerts_zarr_flow(version, overwrite=overwrite)
+    result = integrated_alerts_flow.integrated_alerts_zarr_flow(version,
+                                                                overwrite=overwrite,
+                                                                is_latest=is_latest)
     result_uris.append(result)
 
     return result_uris


### PR DESCRIPTION
Add in the code to record the latest version of integrated alerts in the pipeline
(analogous to what we already do for dist alerts)

We then need to make the change on the analyzer that looks at the 'latest' file,
for the version that it should use, so we don't have to keep updating the
versions in the code.