### PR TITLE
Create API endpoint for land GHG inventory

### DIFF
--- a/api/app/domain/analyzers/land_ghg_inventory_analyzer.py
+++ b/api/app/domain/analyzers/land_ghg_inventory_analyzer.py
@@ -5,9 +5,6 @@ import newrelic.agent as nr_agent
 from app.domain.analyzers.analyzer import Analyzer
 from app.domain.models.analysis import Analysis
 from app.domain.models.environment import Environment
-from app.infrastructure.external_services.duck_db_query_service import (
-    DuckDbPrecalcQueryService,
-)
 from app.models.land_change.land_ghg_inventory import LandGHGInventoryAnalyticsIn
 
 # measures returned per (aoi_id, land_state_class, year)
@@ -34,7 +31,12 @@ class LandGHGInventoryAnalyzer(Analyzer):
     land_state_class x year for admin areas (by aoi_id), read from the precomputed
     zonal-statistics parquet. Admin areas only, no on-the-fly computation."""
 
-    def __init__(self, input_uris: Dict[str, str] | None = None):
+    def __init__(
+        self,
+        duckdb_query_service=None,
+        input_uris: Dict[str, str] | None = None,
+    ):
+        self.duckdb_query_service = duckdb_query_service
         self.input_uris = input_uris
 
     @nr_agent.function_trace(name="LandGHGInventoryAnalyzer.analyze")
@@ -46,15 +48,11 @@ class LandGHGInventoryAnalyzer(Analyzer):
         analysis.result = await self.analyze_admin_areas(analytics_in.aoi.ids)
 
     async def analyze_admin_areas(self, aoi_ids) -> Dict[str, Any]:
-        if self.input_uris is None:
-            raise Exception("Input URIs must be provided for actual analysis")
-
         id_str = (", ").join([f"'{aoi_id}'" for aoi_id in aoi_ids])
         columns = ", ".join(("aoi_id", "land_state_class", "year") + MEASURES)
         query = f"select {columns} from data_source where aoi_id in ({id_str})"
 
-        query_service = DuckDbPrecalcQueryService(self.input_uris["admin_results_uri"])
-        result = await query_service.execute(query)
+        result = await self.duckdb_query_service.execute(query)
         result["aoi_type"] = ["admin"] * len(result["aoi_id"])
 
         return result

--- a/api/app/domain/analyzers/land_ghg_inventory_analyzer.py
+++ b/api/app/domain/analyzers/land_ghg_inventory_analyzer.py
@@ -1,0 +1,60 @@
+from typing import Any, Dict
+
+import newrelic.agent as nr_agent
+
+from app.domain.analyzers.analyzer import Analyzer
+from app.domain.models.analysis import Analysis
+from app.domain.models.environment import Environment
+from app.infrastructure.external_services.duck_db_query_service import (
+    DuckDbPrecalcQueryService,
+)
+from app.models.land_change.land_ghg_inventory import LandGhgInventoryAnalyticsIn
+
+# measures returned per (aoi_id, land_state_class, year)
+MEASURES = (
+    "gross_emissions_MgCO2e",
+    "gross_removals_MgCO2",
+    "net_flux_MgCO2e",
+    "area_ha",
+)
+
+INPUT_URIS = {
+    Environment.staging: {},
+    Environment.production: {
+        "admin_results_uri": (
+            "s3://lcl-analytics/zonal-statistics/land_ghg_inventory-vegetation/"
+            "global/admin-land_ghg_inventory-vegetation.parquet"
+        ),
+    },
+}
+
+
+class LandGhgInventoryAnalyzer(Analyzer):
+    """Vegetation GHG flux (gross emissions / gross removals / net flux) and area by
+    land_state_class x year for GADM admin areas, read from the precomputed
+    zonal-statistics parquet. GADM areas only -- no on-the-fly computation."""
+
+    def __init__(self, input_uris: Dict[str, str] | None = None):
+        self.input_uris = input_uris
+
+    @nr_agent.function_trace(name="LandGhgInventoryAnalyzer.analyze")
+    async def analyze(self, analysis: Analysis) -> None:
+        if self.input_uris is None:
+            raise Exception("Input URIs must be provided for actual analysis")
+
+        analytics_in = LandGhgInventoryAnalyticsIn(**analysis.metadata)
+        analysis.result = await self.analyze_admin_areas(analytics_in.aoi.ids)
+
+    async def analyze_admin_areas(self, gadm_ids) -> Dict[str, Any]:
+        if self.input_uris is None:
+            raise Exception("Input URIs must be provided for actual analysis")
+
+        id_str = (", ").join([f"'{aoi_id}'" for aoi_id in gadm_ids])
+        columns = ", ".join(("aoi_id", "land_state_class", "year") + MEASURES)
+        query = f"select {columns} from data_source where aoi_id in ({id_str})"
+
+        query_service = DuckDbPrecalcQueryService(self.input_uris["admin_results_uri"])
+        result = await query_service.execute(query)
+        result["aoi_type"] = ["admin"] * len(result["aoi_id"])
+
+        return result

--- a/api/app/domain/analyzers/land_ghg_inventory_analyzer.py
+++ b/api/app/domain/analyzers/land_ghg_inventory_analyzer.py
@@ -8,7 +8,7 @@ from app.domain.models.environment import Environment
 from app.infrastructure.external_services.duck_db_query_service import (
     DuckDbPrecalcQueryService,
 )
-from app.models.land_change.land_ghg_inventory import LandGhgInventoryAnalyticsIn
+from app.models.land_change.land_ghg_inventory import LandGHGInventoryAnalyticsIn
 
 # measures returned per (aoi_id, land_state_class, year)
 MEASURES = (
@@ -29,27 +29,27 @@ INPUT_URIS = {
 }
 
 
-class LandGhgInventoryAnalyzer(Analyzer):
+class LandGHGInventoryAnalyzer(Analyzer):
     """Vegetation GHG flux (gross emissions / gross removals / net flux) and area by
-    land_state_class x year for GADM admin areas, read from the precomputed
-    zonal-statistics parquet. GADM areas only -- no on-the-fly computation."""
+    land_state_class x year for admin areas (by aoi_id), read from the precomputed
+    zonal-statistics parquet. Admin areas only, no on-the-fly computation."""
 
     def __init__(self, input_uris: Dict[str, str] | None = None):
         self.input_uris = input_uris
 
-    @nr_agent.function_trace(name="LandGhgInventoryAnalyzer.analyze")
+    @nr_agent.function_trace(name="LandGHGInventoryAnalyzer.analyze")
     async def analyze(self, analysis: Analysis) -> None:
         if self.input_uris is None:
             raise Exception("Input URIs must be provided for actual analysis")
 
-        analytics_in = LandGhgInventoryAnalyticsIn(**analysis.metadata)
+        analytics_in = LandGHGInventoryAnalyticsIn(**analysis.metadata)
         analysis.result = await self.analyze_admin_areas(analytics_in.aoi.ids)
 
-    async def analyze_admin_areas(self, gadm_ids) -> Dict[str, Any]:
+    async def analyze_admin_areas(self, aoi_ids) -> Dict[str, Any]:
         if self.input_uris is None:
             raise Exception("Input URIs must be provided for actual analysis")
 
-        id_str = (", ").join([f"'{aoi_id}'" for aoi_id in gadm_ids])
+        id_str = (", ").join([f"'{aoi_id}'" for aoi_id in aoi_ids])
         columns = ", ".join(("aoi_id", "land_state_class", "year") + MEASURES)
         query = f"select {columns} from data_source where aoi_id in ({id_str})"
 

--- a/api/app/domain/analyzers/land_ghg_inventory_analyzer.py
+++ b/api/app/domain/analyzers/land_ghg_inventory_analyzer.py
@@ -27,9 +27,12 @@ INPUT_URIS = {
 
 
 class LandGHGInventoryAnalyzer(Analyzer):
-    """Vegetation GHG flux (gross emissions / gross removals / net flux) and area by
+    """Land GHG flux (gross emissions / gross removals / net flux) and area by
     land_state_class x year for admin areas (by aoi_id), read from the precomputed
-    zonal-statistics parquet. Admin areas only, no on-the-fly computation."""
+    zonal-statistics parquet. Admin areas only, no on-the-fly computation.
+
+    The result groups tables by aggregation category. Only "vegetation" is
+    produced today; "agriculture" and "soil" become further keys later."""
 
     def __init__(
         self,
@@ -45,7 +48,9 @@ class LandGHGInventoryAnalyzer(Analyzer):
             raise Exception("Input URIs must be provided for actual analysis")
 
         analytics_in = LandGHGInventoryAnalyticsIn(**analysis.metadata)
-        analysis.result = await self.analyze_admin_areas(analytics_in.aoi.ids)
+        analysis.result = {
+            "vegetation": await self.analyze_admin_areas(analytics_in.aoi.ids)
+        }
 
     async def analyze_admin_areas(self, aoi_ids) -> Dict[str, Any]:
         id_str = (", ").join([f"'{aoi_id}'" for aoi_id in aoi_ids])

--- a/api/app/models/land_change/land_ghg_inventory.py
+++ b/api/app/models/land_change/land_ghg_inventory.py
@@ -9,17 +9,17 @@ from ..common.base import Response, StrictBaseModel
 ANALYTICS_NAME = "land_ghg_inventory"
 
 
-class LandGhgInventoryAnalyticsIn(AnalyticsIn):
+class LandGHGInventoryAnalyticsIn(AnalyticsIn):
     _analytics_name: str = PrivateAttr(default=ANALYTICS_NAME)
     _version: str = PrivateAttr(default="v20260723")
     aoi: AdminAreaOfInterest = Field(
         ...,
         title="AOI",
-        description="GADM admin area to summarize. GADM areas only (no on-the-fly).",
+        description="Admin area (by aoi_id). Admin areas only, no on-the-fly.",
     )
 
 
-class LandGhgInventoryAnalytics(StrictBaseModel):
+class LandGHGInventoryAnalytics(StrictBaseModel):
     result: Optional[dict] = None
     metadata: Optional[dict] = None
     message: Optional[str] = None
@@ -31,8 +31,8 @@ class LandGhgInventoryAnalytics(StrictBaseModel):
     }
 
 
-class LandGhgInventoryAnalyticsResponse(Response):
-    data: LandGhgInventoryAnalytics
+class LandGHGInventoryAnalyticsResponse(Response):
+    data: LandGHGInventoryAnalytics
     model_config = {
         "json_schema_extra": {
             "examples": [

--- a/api/app/models/land_change/land_ghg_inventory.py
+++ b/api/app/models/land_change/land_ghg_inventory.py
@@ -1,0 +1,63 @@
+from typing import Optional
+
+from pydantic import Field, PrivateAttr
+
+from ..common.analysis import AnalysisStatus, AnalyticsIn
+from ..common.areas_of_interest import AdminAreaOfInterest
+from ..common.base import Response, StrictBaseModel
+
+ANALYTICS_NAME = "land_ghg_inventory"
+
+
+class LandGhgInventoryAnalyticsIn(AnalyticsIn):
+    _analytics_name: str = PrivateAttr(default=ANALYTICS_NAME)
+    _version: str = PrivateAttr(default="v20260723")
+    aoi: AdminAreaOfInterest = Field(
+        ...,
+        title="AOI",
+        description="GADM admin area to summarize. GADM areas only (no on-the-fly).",
+    )
+
+
+class LandGhgInventoryAnalytics(StrictBaseModel):
+    result: Optional[dict] = None
+    metadata: Optional[dict] = None
+    message: Optional[str] = None
+    status: AnalysisStatus
+
+    model_config = {
+        "from_attributes": True,
+        "validate_by_name": True,
+    }
+
+
+class LandGhgInventoryAnalyticsResponse(Response):
+    data: LandGhgInventoryAnalytics
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "data": {
+                        "result": {  # column oriented for loading into a dataframe
+                            "aoi_id": ["BRA.1", "BRA.1"],
+                            "aoi_type": ["admin", "admin"],
+                            "land_state_class": ["tree_loss", "tree_gain"],
+                            "year": [2016, 2016],
+                            "gross_emissions_MgCO2e": [438480933.0, 0.0],
+                            "gross_removals_MgCO2": [-29404371.0, -3213337.0],
+                            "net_flux_MgCO2e": [409076565.0, -3213337.0],
+                            "area_ha": [1086087.0, 518423.0],
+                        },
+                        "metadata": {
+                            "aoi": {
+                                "type": "admin",
+                                "ids": ["BRA.1"],
+                            },
+                        },
+                        "message": "",
+                        "status": "saved",
+                    }
+                }
+            ]
+        }
+    }

--- a/api/app/models/land_change/land_ghg_inventory.py
+++ b/api/app/models/land_change/land_ghg_inventory.py
@@ -38,15 +38,19 @@ class LandGHGInventoryAnalyticsResponse(Response):
             "examples": [
                 {
                     "data": {
-                        "result": {  # column oriented for loading into a dataframe
-                            "aoi_id": ["BRA.1", "BRA.1"],
-                            "aoi_type": ["admin", "admin"],
-                            "land_state_class": ["tree_loss", "tree_gain"],
-                            "year": [2016, 2016],
-                            "gross_emissions_MgCO2e": [438480933.0, 0.0],
-                            "gross_removals_MgCO2": [-29404371.0, -3213337.0],
-                            "net_flux_MgCO2e": [409076565.0, -3213337.0],
-                            "area_ha": [1086087.0, 518423.0],
+                        # tables grouped by category; "vegetation" only for now
+                        "result": {
+                            # column oriented for loading into a dataframe
+                            "vegetation": {
+                                "aoi_id": ["BRA.1", "BRA.1"],
+                                "aoi_type": ["admin", "admin"],
+                                "land_state_class": ["tree_loss", "tree_gain"],
+                                "year": [2016, 2016],
+                                "gross_emissions_MgCO2e": [438480933.0, 0.0],
+                                "gross_removals_MgCO2": [-29404371.0, -3213337.0],
+                                "net_flux_MgCO2e": [409076565.0, -3213337.0],
+                                "area_ha": [1086087.0, 518423.0],
+                            },
                         },
                         "metadata": {
                             "aoi": {

--- a/api/app/routers/land_change/__init__.py
+++ b/api/app/routers/land_change/__init__.py
@@ -6,6 +6,7 @@ from .dist_alerts import dist_alerts
 from .grasslands import grasslands
 from .integrated_alerts import integrated_alerts
 from .land_cover import land_cover_change, land_cover_composition
+from .land_ghg_inventory import land_ghg_inventory
 from .natural_lands import natural_lands
 from .tree_cover import tree_cover
 from .tree_cover_gain import tree_cover_gain
@@ -21,5 +22,7 @@ router.include_router(tree_cover_gain.router)
 router.include_router(land_cover_change.router)
 router.include_router(land_cover_composition.router)
 router.include_router(natural_lands.router)
+# hidden from the public OpenAPI docs for now (routes still functional)
+router.include_router(land_ghg_inventory.router, include_in_schema=False)
 router.include_router(carbon_flux.router)
 router.include_router(deforestation_luc_emissions_factor.router)

--- a/api/app/routers/land_change/land_ghg_inventory/land_ghg_inventory.py
+++ b/api/app/routers/land_change/land_ghg_inventory/land_ghg_inventory.py
@@ -1,0 +1,100 @@
+from fastapi import APIRouter, BackgroundTasks, Depends, Request
+from fastapi import Response as FastAPIResponse
+from fastapi.responses import ORJSONResponse
+from pydantic import UUID5
+
+from app.dependencies import get_environment
+from app.domain.analyzers.land_ghg_inventory_analyzer import (
+    INPUT_URIS,
+    LandGhgInventoryAnalyzer,
+)
+from app.domain.models.environment import Environment, resolve_uris
+from app.domain.repositories.analysis_repository import AnalysisRepository
+from app.infrastructure.persistence.aws_dynamodb_s3_analysis_repository import (
+    AwsDynamoDbS3AnalysisRepository,
+)
+from app.models.common.analysis import AnalyticsOut
+from app.models.common.base import DataMartResourceLinkResponse
+from app.models.land_change.land_ghg_inventory import (
+    ANALYTICS_NAME,
+    LandGhgInventoryAnalytics,
+    LandGhgInventoryAnalyticsIn,
+    LandGhgInventoryAnalyticsResponse,
+)
+from app.routers.common_analytics import create_analysis, get_analysis
+from app.use_cases.analysis.analysis_service import AnalysisService
+
+router = APIRouter(prefix=f"/{ANALYTICS_NAME}")
+
+
+def get_analysis_repository(request: Request) -> AnalysisRepository:
+    return AwsDynamoDbS3AnalysisRepository(
+        ANALYTICS_NAME, request.app.state.dynamodb_table, request.app.state.s3_client
+    )
+
+
+def create_analysis_service(
+    analysis_repository: AnalysisRepository = Depends(get_analysis_repository),
+    environment: Environment = Depends(get_environment),
+) -> AnalysisService:
+    return AnalysisService(
+        analysis_repository=analysis_repository,
+        analyzer=LandGhgInventoryAnalyzer(
+            input_uris=resolve_uris(INPUT_URIS, environment),
+        ),
+        event=ANALYTICS_NAME,
+    )
+
+
+@router.post(
+    "/analytics",
+    response_class=ORJSONResponse,
+    response_model=DataMartResourceLinkResponse,
+    status_code=202,
+    summary="Create Land GHG Inventory Analysis Task",
+)
+async def create(
+    *,
+    data: LandGhgInventoryAnalyticsIn,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    service: AnalysisService = Depends(create_analysis_service),
+):
+    return await create_analysis(
+        data=data,
+        service=service,
+        request=request,
+        background_tasks=background_tasks,
+        resource_link_callback=_datamart_resource_link_response,
+    )
+
+
+def _datamart_resource_link_response(request, service) -> str:
+    return str(
+        request.url_for(
+            "get_land_ghg_inventory_analytics_result",
+            resource_id=service.resource_thumbprint(),
+        )
+    )
+
+
+@router.get(
+    "/analytics/{resource_id}",
+    response_class=ORJSONResponse,
+    response_model=LandGhgInventoryAnalyticsResponse,
+    status_code=200,
+)
+async def get_land_ghg_inventory_analytics_result(
+    resource_id: UUID5,
+    response: FastAPIResponse,
+    analysis_repository: AnalysisRepository = Depends(get_analysis_repository),
+):
+    analytics_out: AnalyticsOut = await get_analysis(
+        resource_id=resource_id,
+        analysis_repository=analysis_repository,
+        response=response,
+    )
+
+    return LandGhgInventoryAnalyticsResponse(
+        data=LandGhgInventoryAnalytics(**analytics_out.model_dump()), status="success"
+    )

--- a/api/app/routers/land_change/land_ghg_inventory/land_ghg_inventory.py
+++ b/api/app/routers/land_change/land_ghg_inventory/land_ghg_inventory.py
@@ -6,7 +6,7 @@ from pydantic import UUID5
 from app.dependencies import get_environment
 from app.domain.analyzers.land_ghg_inventory_analyzer import (
     INPUT_URIS,
-    LandGhgInventoryAnalyzer,
+    LandGHGInventoryAnalyzer,
 )
 from app.domain.models.environment import Environment, resolve_uris
 from app.domain.repositories.analysis_repository import AnalysisRepository
@@ -17,9 +17,9 @@ from app.models.common.analysis import AnalyticsOut
 from app.models.common.base import DataMartResourceLinkResponse
 from app.models.land_change.land_ghg_inventory import (
     ANALYTICS_NAME,
-    LandGhgInventoryAnalytics,
-    LandGhgInventoryAnalyticsIn,
-    LandGhgInventoryAnalyticsResponse,
+    LandGHGInventoryAnalytics,
+    LandGHGInventoryAnalyticsIn,
+    LandGHGInventoryAnalyticsResponse,
 )
 from app.routers.common_analytics import create_analysis, get_analysis
 from app.use_cases.analysis.analysis_service import AnalysisService
@@ -39,7 +39,7 @@ def create_analysis_service(
 ) -> AnalysisService:
     return AnalysisService(
         analysis_repository=analysis_repository,
-        analyzer=LandGhgInventoryAnalyzer(
+        analyzer=LandGHGInventoryAnalyzer(
             input_uris=resolve_uris(INPUT_URIS, environment),
         ),
         event=ANALYTICS_NAME,
@@ -55,7 +55,7 @@ def create_analysis_service(
 )
 async def create(
     *,
-    data: LandGhgInventoryAnalyticsIn,
+    data: LandGHGInventoryAnalyticsIn,
     request: Request,
     background_tasks: BackgroundTasks,
     service: AnalysisService = Depends(create_analysis_service),
@@ -81,7 +81,7 @@ def _datamart_resource_link_response(request, service) -> str:
 @router.get(
     "/analytics/{resource_id}",
     response_class=ORJSONResponse,
-    response_model=LandGhgInventoryAnalyticsResponse,
+    response_model=LandGHGInventoryAnalyticsResponse,
     status_code=200,
 )
 async def get_land_ghg_inventory_analytics_result(
@@ -95,6 +95,6 @@ async def get_land_ghg_inventory_analytics_result(
         response=response,
     )
 
-    return LandGhgInventoryAnalyticsResponse(
-        data=LandGhgInventoryAnalytics(**analytics_out.model_dump()), status="success"
+    return LandGHGInventoryAnalyticsResponse(
+        data=LandGHGInventoryAnalytics(**analytics_out.model_dump()), status="success"
     )

--- a/api/app/routers/land_change/land_ghg_inventory/land_ghg_inventory.py
+++ b/api/app/routers/land_change/land_ghg_inventory/land_ghg_inventory.py
@@ -10,6 +10,9 @@ from app.domain.analyzers.land_ghg_inventory_analyzer import (
 )
 from app.domain.models.environment import Environment, resolve_uris
 from app.domain.repositories.analysis_repository import AnalysisRepository
+from app.infrastructure.external_services.duck_db_query_service import (
+    DuckDbPrecalcQueryService,
+)
 from app.infrastructure.persistence.aws_dynamodb_s3_analysis_repository import (
     AwsDynamoDbS3AnalysisRepository,
 )
@@ -37,10 +40,14 @@ def create_analysis_service(
     analysis_repository: AnalysisRepository = Depends(get_analysis_repository),
     environment: Environment = Depends(get_environment),
 ) -> AnalysisService:
+    input_uris = resolve_uris(INPUT_URIS, environment)
     return AnalysisService(
         analysis_repository=analysis_repository,
         analyzer=LandGHGInventoryAnalyzer(
-            input_uris=resolve_uris(INPUT_URIS, environment),
+            duckdb_query_service=DuckDbPrecalcQueryService(
+                table_uri=input_uris["admin_results_uri"]
+            ),
+            input_uris=input_uris,
         ),
         event=ANALYTICS_NAME,
     )

--- a/api/test/integration/test_land_ghg_inventory.py
+++ b/api/test/integration/test_land_ghg_inventory.py
@@ -11,7 +11,7 @@ from httpx import ASGITransport, AsyncClient
 
 from app.domain.analyzers.land_ghg_inventory_analyzer import (
     INPUT_URIS,
-    LandGhgInventoryAnalyzer,
+    LandGHGInventoryAnalyzer,
 )
 from app.domain.models.environment import Environment
 from app.domain.repositories.analysis_repository import AnalysisRepository
@@ -22,7 +22,7 @@ from app.main import app
 from app.models.common.areas_of_interest import AdminAreaOfInterest
 from app.models.land_change.land_ghg_inventory import (
     ANALYTICS_NAME,
-    LandGhgInventoryAnalyticsIn,
+    LandGHGInventoryAnalyticsIn,
 )
 from app.routers.land_change.land_ghg_inventory.land_ghg_inventory import (
     create_analysis_service,
@@ -42,20 +42,20 @@ def create_analysis_service_for_tests(
 ) -> AnalysisService:
     return AnalysisService(
         analysis_repository=analysis_repository,
-        analyzer=LandGhgInventoryAnalyzer(
+        analyzer=LandGHGInventoryAnalyzer(
             input_uris=INPUT_URIS[Environment.production]
         ),
         event=ANALYTICS_NAME,
     )
 
 
-class TestLandGhgInventoryPostWithNoPreviousRequest:
+class TestLandGHGInventoryPostWithNoPreviousRequest:
     @pytest_asyncio.fixture
     async def setup(self):
-        analytics_in = LandGhgInventoryAnalyticsIn(
+        analytics_in = LandGHGInventoryAnalyticsIn(
             aoi=AdminAreaOfInterest(type="admin", ids=["BRA.1"])
         )
-        analyzer = LandGhgInventoryAnalyzer(
+        analyzer = LandGHGInventoryAnalyzer(
             input_uris=INPUT_URIS[Environment.production]
         )
         resource_tp = resource_thumbprint(analytics_in, analyzer)

--- a/api/test/integration/test_land_ghg_inventory.py
+++ b/api/test/integration/test_land_ghg_inventory.py
@@ -1,0 +1,108 @@
+from test.integration import (
+    delete_resource_files,
+    resource_thumbprint,
+)
+
+import pytest
+import pytest_asyncio
+from asgi_lifespan import LifespanManager
+from fastapi import Depends
+from httpx import ASGITransport, AsyncClient
+
+from app.domain.analyzers.land_ghg_inventory_analyzer import (
+    INPUT_URIS,
+    LandGhgInventoryAnalyzer,
+)
+from app.domain.models.environment import Environment
+from app.domain.repositories.analysis_repository import AnalysisRepository
+from app.infrastructure.persistence.file_system_analysis_repository import (
+    FileSystemAnalysisRepository,
+)
+from app.main import app
+from app.models.common.areas_of_interest import AdminAreaOfInterest
+from app.models.land_change.land_ghg_inventory import (
+    ANALYTICS_NAME,
+    LandGhgInventoryAnalyticsIn,
+)
+from app.routers.land_change.land_ghg_inventory.land_ghg_inventory import (
+    create_analysis_service,
+    get_analysis_repository,
+)
+from app.use_cases.analysis.analysis_service import AnalysisService
+
+
+def get_file_system_analysis_repository() -> AnalysisRepository:
+    return FileSystemAnalysisRepository(ANALYTICS_NAME)
+
+
+def create_analysis_service_for_tests(
+    analysis_repository: AnalysisRepository = Depends(
+        get_file_system_analysis_repository
+    ),
+) -> AnalysisService:
+    return AnalysisService(
+        analysis_repository=analysis_repository,
+        analyzer=LandGhgInventoryAnalyzer(
+            input_uris=INPUT_URIS[Environment.production]
+        ),
+        event=ANALYTICS_NAME,
+    )
+
+
+class TestLandGhgInventoryPostWithNoPreviousRequest:
+    @pytest_asyncio.fixture
+    async def setup(self):
+        analytics_in = LandGhgInventoryAnalyticsIn(
+            aoi=AdminAreaOfInterest(type="admin", ids=["BRA.1"])
+        )
+        analyzer = LandGhgInventoryAnalyzer(
+            input_uris=INPUT_URIS[Environment.production]
+        )
+        resource_tp = resource_thumbprint(analytics_in, analyzer)
+
+        app.dependency_overrides[create_analysis_service] = (
+            create_analysis_service_for_tests
+        )
+        app.dependency_overrides[get_analysis_repository] = (
+            get_file_system_analysis_repository
+        )
+        delete_resource_files(ANALYTICS_NAME, resource_tp)
+
+        async with LifespanManager(app):
+            async with AsyncClient(
+                transport=ASGITransport(app), base_url="http://testserver"
+            ) as client:
+                test_request = await client.post(
+                    f"/v0/land_change/{ANALYTICS_NAME}/analytics",
+                    json=analytics_in.model_dump(),
+                )
+                yield test_request, resource_tp
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_post_returns_202_accepted(self, setup):
+        test_request, _ = setup
+        assert test_request.status_code == 202
+
+    @pytest.mark.asyncio
+    async def test_post_returns_pending_status(self, setup):
+        test_request, _ = setup
+        assert test_request.json()["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_post_returns_resource_link(self, setup):
+        test_request, resource_tp = setup
+        assert test_request.json()["data"]["link"] == (
+            f"http://testserver/v0/land_change/{ANALYTICS_NAME}/analytics/{resource_tp}"
+        )
+
+
+def test_endpoint_is_hidden_from_openapi_schema_but_registered():
+    # hidden from the public docs...
+    schema = app.openapi()
+    assert not any(ANALYTICS_NAME in path for path in schema["paths"])
+    # ...but the routes still exist and are callable
+    registered = {getattr(route, "path", "") for route in app.routes}
+    assert f"/v0/land_change/{ANALYTICS_NAME}/analytics" in registered
+    assert f"/v0/land_change/{ANALYTICS_NAME}/analytics/{{resource_id}}" in registered

--- a/api/test/integration/test_land_ghg_inventory.py
+++ b/api/test/integration/test_land_ghg_inventory.py
@@ -1,7 +1,9 @@
 from test.integration import (
     delete_resource_files,
     resource_thumbprint,
+    retry_getting_resource,
 )
+from typing import Dict
 
 import pytest
 import pytest_asyncio
@@ -31,6 +33,22 @@ from app.routers.land_change.land_ghg_inventory.land_ghg_inventory import (
 from app.use_cases.analysis.analysis_service import AnalysisService
 
 
+class FakeQueryService:
+    """Stand-in for the precomputed parquet so the full POST -> background ->
+    GET flow runs without touching S3."""
+
+    async def execute(self, query: str) -> Dict:
+        return {
+            "aoi_id": ["BRA.1", "BRA.1"],
+            "land_state_class": ["tree_loss", "tree_gain"],
+            "year": [2016, 2016],
+            "gross_emissions_MgCO2e": [100.0, 0.0],
+            "gross_removals_MgCO2": [-10.0, -20.0],
+            "net_flux_MgCO2e": [90.0, -20.0],
+            "area_ha": [1.0, 2.0],
+        }
+
+
 def get_file_system_analysis_repository() -> AnalysisRepository:
     return FileSystemAnalysisRepository(ANALYTICS_NAME)
 
@@ -43,7 +61,8 @@ def create_analysis_service_for_tests(
     return AnalysisService(
         analysis_repository=analysis_repository,
         analyzer=LandGHGInventoryAnalyzer(
-            input_uris=INPUT_URIS[Environment.production]
+            duckdb_query_service=FakeQueryService(),
+            input_uris=INPUT_URIS[Environment.production],
         ),
         event=ANALYTICS_NAME,
     )
@@ -76,26 +95,47 @@ class TestLandGHGInventoryPostWithNoPreviousRequest:
                     f"/v0/land_change/{ANALYTICS_NAME}/analytics",
                     json=analytics_in.model_dump(),
                 )
-                yield test_request, resource_tp
+                yield test_request, client, resource_tp
 
         app.dependency_overrides.clear()
 
     @pytest.mark.asyncio
     async def test_post_returns_202_accepted(self, setup):
-        test_request, _ = setup
+        test_request, _, _ = setup
         assert test_request.status_code == 202
 
     @pytest.mark.asyncio
     async def test_post_returns_pending_status(self, setup):
-        test_request, _ = setup
+        test_request, _, _ = setup
         assert test_request.json()["status"] == "pending"
 
     @pytest.mark.asyncio
     async def test_post_returns_resource_link(self, setup):
-        test_request, resource_tp = setup
+        test_request, _, resource_tp = setup
         assert test_request.json()["data"]["link"] == (
             f"http://testserver/v0/land_change/{ANALYTICS_NAME}/analytics/{resource_tp}"
         )
+
+    @pytest.mark.asyncio
+    async def test_get_returns_saved_result(self, setup):
+        _, client, resource_tp = setup
+
+        data = await retry_getting_resource(ANALYTICS_NAME, resource_tp, client)
+
+        assert data["status"] == "saved"
+        assert set(data["result"]).issuperset(
+            {
+                "aoi_id",
+                "aoi_type",
+                "land_state_class",
+                "year",
+                "gross_emissions_MgCO2e",
+                "gross_removals_MgCO2",
+                "net_flux_MgCO2e",
+                "area_ha",
+            }
+        )
+        assert set(data["result"]["aoi_type"]) == {"admin"}
 
 
 def test_endpoint_is_hidden_from_openapi_schema_but_registered():

--- a/api/test/integration/test_land_ghg_inventory.py
+++ b/api/test/integration/test_land_ghg_inventory.py
@@ -123,7 +123,10 @@ class TestLandGHGInventoryPostWithNoPreviousRequest:
         data = await retry_getting_resource(ANALYTICS_NAME, resource_tp, client)
 
         assert data["status"] == "saved"
-        assert set(data["result"]).issuperset(
+        # tables are nested by category; only "vegetation" exists for now
+        assert set(data["result"]) == {"vegetation"}
+        vegetation = data["result"]["vegetation"]
+        assert set(vegetation).issuperset(
             {
                 "aoi_id",
                 "aoi_type",
@@ -135,7 +138,7 @@ class TestLandGHGInventoryPostWithNoPreviousRequest:
                 "area_ha",
             }
         )
-        assert set(data["result"]["aoi_type"]) == {"admin"}
+        assert set(vegetation["aoi_type"]) == {"admin"}
 
 
 def test_endpoint_is_hidden_from_openapi_schema_but_registered():

--- a/api/test/unit/domain/analyzers/test_land_ghg_inventory_analyzer.py
+++ b/api/test/unit/domain/analyzers/test_land_ghg_inventory_analyzer.py
@@ -1,7 +1,3 @@
-from typing import Dict
-from unittest.mock import patch
-
-import duckdb
 import pandas as pd
 import pytest
 from pydantic import ValidationError
@@ -12,6 +8,9 @@ from app.domain.analyzers.land_ghg_inventory_analyzer import (
 )
 from app.domain.models.analysis import Analysis
 from app.domain.models.environment import Environment
+from app.infrastructure.external_services.duck_db_query_service import (
+    DuckDbPrecalcQueryService,
+)
 from app.models.common.analysis import AnalysisStatus
 from app.models.common.areas_of_interest import (
     AdminAreaOfInterest,
@@ -31,42 +30,41 @@ EXPECTED_COLUMNS = {
 }
 
 
-class FakeParquetQueryService:
-    """Runs the analyzer's real SQL against an in-memory parquet stand-in."""
-
-    async def execute(self, query: str) -> Dict:
-        data_source = pd.DataFrame(  # noqa: F841 (resolved by duckdb.sql scope)
-            {
-                "aoi_id": ["BRA.1", "BRA.1", "COL", "PER"],
-                "land_state_class": [
-                    "tree_loss",
-                    "tree_gain",
-                    "tree_loss",
-                    "tree_loss",
-                ],
-                "year": [2016, 2016, 2016, 2016],
-                "gross_emissions_MgCO2e": [100.0, 0.0, 50.0, 5.0],
-                "gross_removals_MgCO2": [-10.0, -20.0, -5.0, -1.0],
-                "net_flux_MgCO2e": [90.0, -20.0, 45.0, 4.0],
-                "area_ha": [1.0, 2.0, 3.0, 4.0],
-            }
-        )
-        return duckdb.sql(query).df().to_dict(orient="list")
+@pytest.fixture
+def precomputed_gadm_results(tmp_path):
+    """Real precomputed zonal-statistics parquet, queried through the real adapter."""
+    df = pd.DataFrame(
+        {
+            "aoi_id": ["BRA.1", "BRA.1", "COL", "PER"],
+            "land_state_class": ["tree_loss", "tree_gain", "tree_loss", "tree_loss"],
+            "year": [2016, 2016, 2016, 2016],
+            "gross_emissions_MgCO2e": [100.0, 0.0, 50.0, 5.0],
+            "gross_removals_MgCO2": [-10.0, -20.0, -5.0, -1.0],
+            "net_flux_MgCO2e": [90.0, -20.0, 45.0, 4.0],
+            "area_ha": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+    parquet_file = tmp_path / "land_ghg_inventory_data.parquet"
+    df.to_parquet(parquet_file, index=False)
+    return parquet_file
 
 
 @pytest.mark.asyncio
-async def test_admin_query_returns_flux_by_land_state_and_year():
+async def test_admin_query_returns_flux_by_land_state_and_year(
+    precomputed_gadm_results,
+):
     analytics_in = LandGHGInventoryAnalyticsIn(
         aoi=AdminAreaOfInterest(ids=["BRA.1", "COL"])
     ).model_dump()
     analysis = Analysis(None, analytics_in, AnalysisStatus.saved)
-    analyzer = LandGHGInventoryAnalyzer(input_uris=INPUT_URIS[Environment.production])
+    analyzer = LandGHGInventoryAnalyzer(
+        duckdb_query_service=DuckDbPrecalcQueryService(
+            table_uri=precomputed_gadm_results
+        ),
+        input_uris=INPUT_URIS[Environment.production],
+    )
 
-    with patch(
-        "app.domain.analyzers.land_ghg_inventory_analyzer.DuckDbPrecalcQueryService"
-    ) as mock_qs:
-        mock_qs.return_value.execute = FakeParquetQueryService().execute
-        await analyzer.analyze(analysis)
+    await analyzer.analyze(analysis)
 
     result = pd.DataFrame(analysis.result)
     assert EXPECTED_COLUMNS.issubset(result.columns)

--- a/api/test/unit/domain/analyzers/test_land_ghg_inventory_analyzer.py
+++ b/api/test/unit/domain/analyzers/test_land_ghg_inventory_analyzer.py
@@ -8,7 +8,7 @@ from pydantic import ValidationError
 
 from app.domain.analyzers.land_ghg_inventory_analyzer import (
     INPUT_URIS,
-    LandGhgInventoryAnalyzer,
+    LandGHGInventoryAnalyzer,
 )
 from app.domain.models.analysis import Analysis
 from app.domain.models.environment import Environment
@@ -17,7 +17,7 @@ from app.models.common.areas_of_interest import (
     AdminAreaOfInterest,
     KeyBiodiversityAreaOfInterest,
 )
-from app.models.land_change.land_ghg_inventory import LandGhgInventoryAnalyticsIn
+from app.models.land_change.land_ghg_inventory import LandGHGInventoryAnalyticsIn
 
 EXPECTED_COLUMNS = {
     "aoi_id",
@@ -56,11 +56,11 @@ class FakeParquetQueryService:
 
 @pytest.mark.asyncio
 async def test_admin_query_returns_flux_by_land_state_and_year():
-    analytics_in = LandGhgInventoryAnalyticsIn(
+    analytics_in = LandGHGInventoryAnalyticsIn(
         aoi=AdminAreaOfInterest(ids=["BRA.1", "COL"])
     ).model_dump()
     analysis = Analysis(None, analytics_in, AnalysisStatus.saved)
-    analyzer = LandGhgInventoryAnalyzer(input_uris=INPUT_URIS[Environment.production])
+    analyzer = LandGHGInventoryAnalyzer(input_uris=INPUT_URIS[Environment.production])
 
     with patch(
         "app.domain.analyzers.land_ghg_inventory_analyzer.DuckDbPrecalcQueryService"
@@ -70,7 +70,7 @@ async def test_admin_query_returns_flux_by_land_state_and_year():
 
     result = pd.DataFrame(analysis.result)
     assert EXPECTED_COLUMNS.issubset(result.columns)
-    # only the requested GADM ids come back (PER is filtered out by the WHERE clause)
+    # only the requested admin ids come back (PER is filtered out by the WHERE clause)
     assert set(result.aoi_id) == {"BRA.1", "COL"}
     assert set(result.aoi_type) == {"admin"}
     # tree_gain keeps its structural zero emissions (dense output, not NaN)
@@ -81,10 +81,10 @@ async def test_admin_query_returns_flux_by_land_state_and_year():
     assert tree_gain.net_flux_MgCO2e == -20.0
 
 
-def test_rejects_non_gadm_aoi():
-    # GADM areas only: a non-admin AOI must fail validation, not fall through to OTF.
+def test_rejects_non_admin_aoi():
+    # Admin areas only: a non-admin AOI must fail validation, not fall through to OTF.
     with pytest.raises(ValidationError):
-        LandGhgInventoryAnalyticsIn(
+        LandGHGInventoryAnalyticsIn(
             aoi=KeyBiodiversityAreaOfInterest(
                 type="key_biodiversity_area", ids=["8111"]
             )

--- a/api/test/unit/domain/analyzers/test_land_ghg_inventory_analyzer.py
+++ b/api/test/unit/domain/analyzers/test_land_ghg_inventory_analyzer.py
@@ -1,0 +1,91 @@
+from typing import Dict
+from unittest.mock import patch
+
+import duckdb
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+
+from app.domain.analyzers.land_ghg_inventory_analyzer import (
+    INPUT_URIS,
+    LandGhgInventoryAnalyzer,
+)
+from app.domain.models.analysis import Analysis
+from app.domain.models.environment import Environment
+from app.models.common.analysis import AnalysisStatus
+from app.models.common.areas_of_interest import (
+    AdminAreaOfInterest,
+    KeyBiodiversityAreaOfInterest,
+)
+from app.models.land_change.land_ghg_inventory import LandGhgInventoryAnalyticsIn
+
+EXPECTED_COLUMNS = {
+    "aoi_id",
+    "aoi_type",
+    "land_state_class",
+    "year",
+    "gross_emissions_MgCO2e",
+    "gross_removals_MgCO2",
+    "net_flux_MgCO2e",
+    "area_ha",
+}
+
+
+class FakeParquetQueryService:
+    """Runs the analyzer's real SQL against an in-memory parquet stand-in."""
+
+    async def execute(self, query: str) -> Dict:
+        data_source = pd.DataFrame(  # noqa: F841 (resolved by duckdb.sql scope)
+            {
+                "aoi_id": ["BRA.1", "BRA.1", "COL", "PER"],
+                "land_state_class": [
+                    "tree_loss",
+                    "tree_gain",
+                    "tree_loss",
+                    "tree_loss",
+                ],
+                "year": [2016, 2016, 2016, 2016],
+                "gross_emissions_MgCO2e": [100.0, 0.0, 50.0, 5.0],
+                "gross_removals_MgCO2": [-10.0, -20.0, -5.0, -1.0],
+                "net_flux_MgCO2e": [90.0, -20.0, 45.0, 4.0],
+                "area_ha": [1.0, 2.0, 3.0, 4.0],
+            }
+        )
+        return duckdb.sql(query).df().to_dict(orient="list")
+
+
+@pytest.mark.asyncio
+async def test_admin_query_returns_flux_by_land_state_and_year():
+    analytics_in = LandGhgInventoryAnalyticsIn(
+        aoi=AdminAreaOfInterest(ids=["BRA.1", "COL"])
+    ).model_dump()
+    analysis = Analysis(None, analytics_in, AnalysisStatus.saved)
+    analyzer = LandGhgInventoryAnalyzer(input_uris=INPUT_URIS[Environment.production])
+
+    with patch(
+        "app.domain.analyzers.land_ghg_inventory_analyzer.DuckDbPrecalcQueryService"
+    ) as mock_qs:
+        mock_qs.return_value.execute = FakeParquetQueryService().execute
+        await analyzer.analyze(analysis)
+
+    result = pd.DataFrame(analysis.result)
+    assert EXPECTED_COLUMNS.issubset(result.columns)
+    # only the requested GADM ids come back (PER is filtered out by the WHERE clause)
+    assert set(result.aoi_id) == {"BRA.1", "COL"}
+    assert set(result.aoi_type) == {"admin"}
+    # tree_gain keeps its structural zero emissions (dense output, not NaN)
+    tree_gain = result[
+        (result.aoi_id == "BRA.1") & (result.land_state_class == "tree_gain")
+    ].iloc[0]
+    assert tree_gain.gross_emissions_MgCO2e == 0.0
+    assert tree_gain.net_flux_MgCO2e == -20.0
+
+
+def test_rejects_non_gadm_aoi():
+    # GADM areas only: a non-admin AOI must fail validation, not fall through to OTF.
+    with pytest.raises(ValidationError):
+        LandGhgInventoryAnalyticsIn(
+            aoi=KeyBiodiversityAreaOfInterest(
+                type="key_biodiversity_area", ids=["8111"]
+            )
+        )

--- a/api/test/unit/domain/analyzers/test_land_ghg_inventory_analyzer.py
+++ b/api/test/unit/domain/analyzers/test_land_ghg_inventory_analyzer.py
@@ -66,7 +66,9 @@ async def test_admin_query_returns_flux_by_land_state_and_year(
 
     await analyzer.analyze(analysis)
 
-    result = pd.DataFrame(analysis.result)
+    # the table is nested under the "vegetation" key (agriculture/soil added later)
+    assert set(analysis.result) == {"vegetation"}
+    result = pd.DataFrame(analysis.result["vegetation"])
     assert EXPECTED_COLUMNS.issubset(result.columns)
     # only the requested admin ids come back (PER is filtered out by the WHERE clause)
     assert set(result.aoi_id) == {"BRA.1", "COL"}


### PR DESCRIPTION
## API usage & validation

`land_ghg_inventory` is a hidden (not in `/docs`), GADM-only endpoint that reads the
precomputed zonal-statistics parquet via DuckDB and returns vegetation GHG flux by
`land_state_class × year`.

### Request

```bash
curl -X POST http://localhost:8000/v0/land_change/land_ghg_inventory/analytics \
  -H "Content-Type: application/json" \
  -d '{"aoi": {"type": "admin", "ids": ["STP"]}}'
```

### Response — `202 Accepted` (long-running; poll the link)

```json
{
  "data": {
    "link": "http://localhost:8000/v0/land_change/land_ghg_inventory/analytics/c6b2b348-91c7-557d-b9f6-34bffa35be66"
  },
  "status": "pending"
}
```

### `GET` the link → `200`, `status: "saved"`

Column-oriented result (truncated to 3 of 26 rows):

```json
{
  "data": {
    "result": {
      "vegetation": {                     
        "aoi_id": ["BRA.1", "BRA.1"],
        "aoi_type": ["admin", "admin"],
        "land_state_class": ["tree_loss", "tree_gain"],
        "year": [2016, 2016],
        "gross_emissions_MgCO2e": [438480933.0, 0.0],
        "gross_removals_MgCO2": [-29404371.0, -3213337.0],
        "net_flux_MgCO2e": [409076565.0, -3213337.0],
        "area_ha": [1086087.0, 518423.0]
      }
    },
    "metadata": { "aoi": { "type": "admin", "ids": ["BRA.1"] } },
    "message": "Analysis completed successfully.",
    "status": "saved"
  },
  "status": "success"
}

```

| land_state_class | year | gross_emissions_MgCO2e | gross_removals_MgCO2 | net_flux_MgCO2e | area_ha |
|---|---|---|---|---|---|
| tree_loss | 2020 | 3259.55 | 0.00 | 3259.55 | 21.00 |
| tree_gain | 2021 | 0.00 | −272.86 | −272.86 | 18.69 |
| trees_remaining_trees | 2016 | 18.63 | −1,352,015.99 | −1,351,997.36 | 95,822.10 |

Non-GADM AOIs (e.g. `key_biodiversity_area`) are rejected with `422` — GADM only, no on-the-fly.

### Correctness

The endpoint's output reproduces the researcher reference parquet exactly for São Tomé
& Príncipe, per `land_state_class × year`:

| check | result |
|---|---|
| (class × year) rows matched | 26 / 26 |
| max abs difference (any cell) | **0.14 MgCO₂e** (on values up to ~1.35 M) |
| STP total gross_emissions_MgCO2e | 10,426.5 (Δ 0.002) |
| STP total gross_removals_MgCO2 | −11,666,091 (Δ 0.9) |
| STP total net_flux_MgCO2e | −11,655,664 (Δ 0.36) |

Differences are floating-point rounding only.
