### PR TITLE
PZB-1208: add agriculture ghg inventory pipeline; clean separation of components

### DIFF
--- a/pipelines/globals.py
+++ b/pipelines/globals.py
@@ -34,6 +34,12 @@ land_ghg_inventory_soc_zarr_uri = (
     "s3://gfw2-data/climate/AFOLU_flux_model/LULUCF/outputs_soil_organic_carbon/"
     "version_1_0_1__standard__global/zarr/4000_pixels/20260611/SOC_zarr.zarr"
 )
+# Agriculture emissions (cropland + livestock). Single static snapshot, no year
+# axis; per-pixel absolute totals (not per-hectare). group="pipeline".
+land_ghg_inventory_agriculture_zarr_uri = (
+    f"s3://{ANALYTICS_BUCKET}/zarr/land-ghg-monitoring-system/"
+    "cropland_livestock_emissions.zarr"
+)
 
 grasslands_zarr_uri = f"s3://{ANALYTICS_BUCKET}/zarr/grasslands/v1/grasslands.zarr"
 sbtn_natural_lands_zarr_uri = f"s3://{ANALYTICS_BUCKET}/zarr/sbtn-natural-lands/sbtn_natural_lands_all_classes.zarr"

--- a/pipelines/land_ghg_inventory/agriculture_stages.py
+++ b/pipelines/land_ghg_inventory/agriculture_stages.py
@@ -4,6 +4,13 @@ Sums already-absolute per-pixel cropland + livestock emissions grouped by admin
 unit x category (cropland / livestock) only (no land_state_class, no year — a
 single static snapshot), then rolls up to aoi_id. The reduce and GADM roll-up are
 reused from ``pipelines.prefect_flows.common_stages``.
+
+Output parquet schema (one row per aoi_id x category)::
+
+    aoi_id                    str    admin unit, e.g. "BRA", "BRA.1", "BRA.1.1"
+    aoi_type                  str    always "admin"
+    category                  str    "cropland" | "livestock"
+    gross_emissions_MgCO2e    float  summed emissions for aoi_id x category
 """
 
 from typing import Optional, Tuple

--- a/pipelines/land_ghg_inventory/agriculture_stages.py
+++ b/pipelines/land_ghg_inventory/agriculture_stages.py
@@ -1,9 +1,9 @@
 """Zonal-statistics stages for Land GHG inventory agriculture emissions.
 
 Sums already-absolute per-pixel cropland + livestock emissions grouped by admin
-unit only (no land_state_class, no year — a single static snapshot), then rolls up
-to aoi_id. The reduce and GADM roll-up are reused from
-``pipelines.prefect_flows.common_stages``.
+unit x category (cropland / livestock) only (no land_state_class, no year — a
+single static snapshot), then rolls up to aoi_id. The reduce and GADM roll-up are
+reused from ``pipelines.prefect_flows.common_stages``.
 """
 
 from typing import Optional, Tuple
@@ -23,10 +23,10 @@ from pipelines.prefect_flows.common_stages import (
     rollup_by_gadm_and_convert_to_aoi,
 )
 
-# canonical measure -> source variable in the agriculture zarr
+# canonical category -> source variable in the agriculture zarr
 AGRICULTURE_SOURCE_VARS = {
-    "cropland_emissions": "cropland_emissions",
-    "livestock_emissions": "livestock_emissions",
+    "cropland": "cropland_emissions",
+    "livestock": "livestock_emissions",
 }
 AGRICULTURE_ZARR_GROUP = "pipeline"
 
@@ -58,18 +58,11 @@ def load_agriculture(
 def setup_agriculture_compute(datasets: Tuple, expected_groups: Tuple) -> Tuple:
     """Build the agriculture measure cube + admin group-by layers for the reduce.
 
-    Unlike vegetation, agriculture values are already per-pixel absolute totals (no
-    pixel-area multiplication), and there is no land_state_class or year axis —
-    grouping is admin-only (country x region x subregion).
+    Stacks the per-pixel absolute cropland/livestock totals into a ``category``
+    dim; grouping is admin-only (country x region x subregion).
     """
     ag, country, region, subregion = datasets
-    layers = [
-        ag[name].fillna(0).astype("float64").rename(name)
-        for name in AGRICULTURE_SOURCE_VARS
-    ]
-    cube = xr.concat(layers, dim="analysis_layer").assign_coords(
-        analysis_layer=list(AGRICULTURE_SOURCE_VARS)
-    )
+    cube = ag.fillna(0).astype("float64").to_dataarray(dim="category")
     groupbys = (
         country.rename("country"),
         region.rename("region"),
@@ -79,23 +72,15 @@ def setup_agriculture_compute(datasets: Tuple, expected_groups: Tuple) -> Tuple:
 
 
 def agriculture_result_dataframe(reduced: xr.DataArray) -> pd.DataFrame:
-    """Reshape the sparse agriculture reduce into tidy aoi_id rows.
+    """Reshape the sparse agriculture reduce into tidy aoi_id x category rows.
 
-    Mirrors vegetation's ``create_result_dataframe`` and carbon_flux's pivot (see
-    ``pipelines/carbon_flux/stages.py``): ``common_create_result_dataframe`` only
-    supports a single ``DataArray`` with the measures stacked on ``analysis_layer``
-    (not a multi-variable ``Dataset``), so they're pivoted back into columns here.
+    Cropland and livestock emissions stay as separate rows (one per admin unit
+    x category) rather than columns, so consumers group/filter by ``category``.
     """
     df = common_create_result_dataframe(reduced)
-    df = df.pivot_table(
-        index=["country", "region", "subregion"],
-        columns="analysis_layer",
-        values="value",
-        aggfunc="sum",
-    ).reset_index()
-    df.columns.name = None
+    df = df.rename(columns={"value": "gross_emissions_MgCO2e"})
 
-    result = rollup_by_gadm_and_convert_to_aoi(df, [])
-    value_columns = list(AGRICULTURE_SOURCE_VARS)
+    result = rollup_by_gadm_and_convert_to_aoi(df, ["category"])
+    value_columns = ["gross_emissions_MgCO2e"]
     result[value_columns] = result.reindex(columns=value_columns).fillna(0.0)
     return result

--- a/pipelines/land_ghg_inventory/agriculture_stages.py
+++ b/pipelines/land_ghg_inventory/agriculture_stages.py
@@ -1,0 +1,101 @@
+"""Zonal-statistics stages for Land GHG inventory agriculture emissions.
+
+Sums already-absolute per-pixel cropland + livestock emissions grouped by admin
+unit only (no land_state_class, no year — a single static snapshot), then rolls up
+to aoi_id. The reduce and GADM roll-up are reused from
+``pipelines.prefect_flows.common_stages``.
+"""
+
+from typing import Optional, Tuple
+
+import pandas as pd
+import xarray as xr
+from shapely.geometry import Polygon
+
+from pipelines.land_ghg_inventory.common import align_to, clip
+from pipelines.prefect_flows.common_stages import (
+    _load_zarr,
+)
+from pipelines.prefect_flows.common_stages import (
+    create_result_dataframe as common_create_result_dataframe,
+)
+from pipelines.prefect_flows.common_stages import (
+    rollup_by_gadm_and_convert_to_aoi,
+)
+
+# canonical measure -> source variable in the agriculture zarr
+AGRICULTURE_SOURCE_VARS = {
+    "cropland_emissions": "cropland_emissions",
+    "livestock_emissions": "livestock_emissions",
+}
+AGRICULTURE_ZARR_GROUP = "pipeline"
+
+
+def load_agriculture(
+    agriculture_uri: str,
+    country_uri: str,
+    region_uri: str,
+    subregion_uri: str,
+    bbox: Optional[Polygon] = None,
+) -> Tuple[xr.Dataset, xr.DataArray, xr.DataArray, xr.DataArray]:
+    """Load the agriculture emissions (already per-pixel absolute totals, no year
+    axis) and GADM layers, aligned to the agriculture grid."""
+    ag = _load_zarr(agriculture_uri, group=AGRICULTURE_ZARR_GROUP)[
+        list(AGRICULTURE_SOURCE_VARS.values())
+    ]
+    if "band" in ag.dims:
+        ag = ag.isel(band=0, drop=True)
+    ag = clip(ag, bbox)
+    ag = ag.rename({source: name for name, source in AGRICULTURE_SOURCE_VARS.items()})
+    return (
+        ag,
+        align_to(ag, country_uri),
+        align_to(ag, region_uri),
+        align_to(ag, subregion_uri),
+    )
+
+
+def setup_agriculture_compute(datasets: Tuple, expected_groups: Tuple) -> Tuple:
+    """Build the agriculture measure cube + admin group-by layers for the reduce.
+
+    Unlike vegetation, agriculture values are already per-pixel absolute totals (no
+    pixel-area multiplication), and there is no land_state_class or year axis —
+    grouping is admin-only (country x region x subregion).
+    """
+    ag, country, region, subregion = datasets
+    layers = [
+        ag[name].fillna(0).astype("float64").rename(name)
+        for name in AGRICULTURE_SOURCE_VARS
+    ]
+    cube = xr.concat(layers, dim="analysis_layer").assign_coords(
+        analysis_layer=list(AGRICULTURE_SOURCE_VARS)
+    )
+    groupbys = (
+        country.rename("country"),
+        region.rename("region"),
+        subregion.rename("subregion"),
+    )
+    return (cube, groupbys, expected_groups)
+
+
+def agriculture_result_dataframe(reduced: xr.DataArray) -> pd.DataFrame:
+    """Reshape the sparse agriculture reduce into tidy aoi_id rows.
+
+    Mirrors vegetation's ``create_result_dataframe`` and carbon_flux's pivot (see
+    ``pipelines/carbon_flux/stages.py``): ``common_create_result_dataframe`` only
+    supports a single ``DataArray`` with the measures stacked on ``analysis_layer``
+    (not a multi-variable ``Dataset``), so they're pivoted back into columns here.
+    """
+    df = common_create_result_dataframe(reduced)
+    df = df.pivot_table(
+        index=["country", "region", "subregion"],
+        columns="analysis_layer",
+        values="value",
+        aggfunc="sum",
+    ).reset_index()
+    df.columns.name = None
+
+    result = rollup_by_gadm_and_convert_to_aoi(df, [])
+    value_columns = list(AGRICULTURE_SOURCE_VARS)
+    result[value_columns] = result.reindex(columns=value_columns).fillna(0.0)
+    return result

--- a/pipelines/land_ghg_inventory/common.py
+++ b/pipelines/land_ghg_inventory/common.py
@@ -1,0 +1,24 @@
+"""Shared, dataset-agnostic helpers for Land GHG inventory stages."""
+
+from typing import Optional
+
+import xarray as xr
+from shapely.geometry import Polygon
+
+from pipelines.prefect_flows.common_stages import _load_zarr
+
+
+def align_to(reference: xr.Dataset, uri: str) -> xr.DataArray:
+    """Load a contextual band_data zarr and snap it to the reference grid."""
+    layer = _load_zarr(uri).band_data
+    if "band" in layer.dims:
+        layer = layer.isel(band=0, drop=True)
+    layer = layer.reindex_like(reference, method="nearest", tolerance=1e-4)
+    return xr.align(reference, layer, join="left")[1]
+
+
+def clip(dataset: xr.Dataset, bbox: Optional[Polygon]) -> xr.Dataset:
+    if bbox is None:
+        return dataset
+    min_x, min_y, max_x, max_y = bbox.bounds
+    return dataset.sel(x=slice(min_x, max_x), y=slice(max_y, min_y))

--- a/pipelines/land_ghg_inventory/create_agriculture_zarr.py
+++ b/pipelines/land_ghg_inventory/create_agriculture_zarr.py
@@ -1,0 +1,95 @@
+"""Builds the agriculture emissions zarr consumed by ``agriculture_stages``.
+
+Cropland and livestock emissions are published as global COGs on their own native
+grids (~10km, WGS84), each carrying an absolute per-pixel total in kg. This
+resamples both onto the vegetation zarr's 30m grid (the reference grid for the
+whole Land GHG inventory) via ``odc.geo``'s dask-parallel reprojection, converts
+kg -> Mg, and writes a single two-variable zarr matching
+``agriculture_stages.AGRICULTURE_SOURCE_VARS``.
+"""
+
+import rasterio
+import rioxarray as rio
+import xarray as xr
+from odc.geo.xr import xr_reproject
+
+from pipelines.globals import (
+    land_ghg_inventory_agriculture_zarr_uri,
+    land_ghg_inventory_vegetation_zarr_uri,
+)
+from pipelines.land_ghg_inventory.agriculture_stages import (
+    AGRICULTURE_SOURCE_VARS,
+    AGRICULTURE_ZARR_GROUP,
+)
+from pipelines.utils import s3_uri_exists
+
+# Any per-hectare flux variable in the vegetation zarr works as the reference grid --
+# only its geobox (30m, EPSG:4326) is used, not its values.
+REFERENCE_GRID_VAR = "gross_emissions__all_C_pools__all_gases__MgCO2e_ha_yr"
+
+# Source COGs: static snapshots (single year, no versioning scheme), published by
+# Cornell. Absolute per-pixel totals in kg.
+CROPLAND_COG_URI = (
+    "s3://gfw2-data/climate/AFOLU_flux_model/cropland_emissions/processed/"
+    "Cornell_v20250828/year_2020/global_COG/all_sources/"
+    "Global_grid_all_GHGs_cropland_total_amount_CO2eq_all_crops_NonPeatland_"
+    "2019_kg_CO2_COG.tif"
+)
+LIVESTOCK_COG_URI = (
+    "s3://gfw2-data/climate/AFOLU_flux_model/livestock_emissions/raw__from_Cornell/"
+    "20251223/Total_GHG_Emissions/Tot_CO2eq_kg_livestock_GHG_emissions.tif"
+)
+KG_PER_MG = 1_000
+
+
+def _reference_geobox():
+    """The vegetation zarr's 30m grid, which the agriculture rasters resample to."""
+    ref = xr.open_zarr(
+        land_ghg_inventory_vegetation_zarr_uri,
+        storage_options={"requester_pays": True},
+    )[REFERENCE_GRID_VAR]
+    ref = ref.isel(year=0, drop=True)
+    ref.rio.write_crs("EPSG:4326", inplace=True)
+    return ref.odc.geobox
+
+
+def _resample(cog_uri: str, geobox) -> xr.DataArray:
+    """Reproject one source COG (kg) onto ``geobox``, converting to Mg."""
+    with rasterio.Env(AWS_REQUEST_PAYER="requester"):
+        src = rio.open_rasterio(cog_uri, chunks={"x": 10000, "y": 10000})
+    reprojected = xr_reproject(
+        src,
+        geobox,
+        dst_nodata=0,
+        chunks=(10000, 10000),
+        always_yx=True,
+    )
+    if "band" in reprojected.dims:
+        reprojected = reprojected.isel(band=0, drop=True)
+    return reprojected / KG_PER_MG
+
+
+def create_agriculture_zarr(overwrite: bool = False) -> str:
+    """Resample cropland + livestock emissions onto the vegetation grid and write
+    the combined zarr consumed by ``agriculture_stages.load_agriculture``."""
+    marker_uri = (
+        f"{land_ghg_inventory_agriculture_zarr_uri}/{AGRICULTURE_ZARR_GROUP}/zarr.json"
+    )
+    if not overwrite and s3_uri_exists(marker_uri):
+        return land_ghg_inventory_agriculture_zarr_uri
+
+    geobox = _reference_geobox()
+    cropland = _resample(CROPLAND_COG_URI, geobox)
+    livestock = _resample(LIVESTOCK_COG_URI, geobox)
+
+    combined = xr.Dataset(
+        {
+            AGRICULTURE_SOURCE_VARS["cropland"]: cropland,
+            AGRICULTURE_SOURCE_VARS["livestock"]: livestock,
+        }
+    )
+    combined.to_zarr(
+        land_ghg_inventory_agriculture_zarr_uri, group=AGRICULTURE_ZARR_GROUP, mode="w"
+    )
+
+    return land_ghg_inventory_agriculture_zarr_uri

--- a/pipelines/land_ghg_inventory/prefect_flows/land_ghg_inventory_flow.py
+++ b/pipelines/land_ghg_inventory/prefect_flows/land_ghg_inventory_flow.py
@@ -11,6 +11,7 @@ from pipelines.globals import (
     gadm_country_code_count,
     gadm_region_code_count,
     gadm_subregion_code_count,
+    land_ghg_inventory_agriculture_zarr_uri,
     land_ghg_inventory_vegetation_zarr_uri,
     pixel_area_zarr_uri,
     region_zarr_uri,
@@ -26,8 +27,31 @@ VEGETATION_CATEGORY_COUNT = 5  # 0=excluded .. 4=non_trees_remaining_non_trees
 YEAR_COUNT = 9  # year index 0..8 -> 2016..2024
 
 
-def _vegetation_result_df(bbox=None):
-    """Run the vegetation reduce and return its tidy component rows."""
+@flow(name="Land GHG inventory vegetation", retries=2, retry_delay_seconds=120)
+def land_ghg_inventory_vegetation(
+    version: str,
+    overwrite: bool = False,
+    bbox: Optional[Polygon] = None,
+) -> str:
+    """Land GHG inventory vegetation land-flux zonal stats: gross emissions /
+    removals / net flux and area, grouped by ``land_state_class`` (tree loss /
+    tree gain / trees-remaining / non-trees-remaining) x year, rolled up to aoi_id.
+
+    ``bbox`` clips the reduce to one area for a laptop-friendly local run; the
+    result is written to a local parquet
+    (``admin-land_ghg_inventory-vegetation-{version}.parquet``) instead of the
+    canonical global S3 path (which would be a partial write)."""
+    if bbox is None:
+        result_uri = (
+            f"s3://{ANALYTICS_BUCKET}/zonal-statistics/land_ghg_inventory-vegetation/"
+            f"{version}/admin-land_ghg_inventory-vegetation.parquet"
+        )
+        if not overwrite and s3_uri_exists(result_uri):
+            return result_uri
+    else:
+        # local bbox test run
+        result_uri = f"admin-land_ghg_inventory-vegetation-{version}.parquet"
+
     expected_groups = (
         np.arange(gadm_country_code_count),
         np.arange(gadm_region_code_count),
@@ -51,42 +75,104 @@ def _vegetation_result_df(bbox=None):
     reduced = common_tasks.compute_zonal_stat.with_options(
         name="land_ghg_inventory-vegetation-compute-zonal-stats"
     )(*compute_input, funcname="sum")
-    return land_ghg_inventory_tasks.vegetation_result_dataframe.with_options(
+    result_df = land_ghg_inventory_tasks.vegetation_result_dataframe.with_options(
         name="land_ghg_inventory-vegetation-postprocess-result"
     )(reduced)
+    return common_tasks.save_result.with_options(
+        name="land_ghg_inventory-vegetation-save-result"
+    )(result_df, result_uri)
 
 
-@flow(name="Land GHG inventory vegetation area", retries=2, retry_delay_seconds=120)
-def land_ghg_inventory_area(
+@flow(name="Land GHG inventory agriculture", retries=2, retry_delay_seconds=120)
+def land_ghg_inventory_agriculture(
     version: str,
     overwrite: bool = False,
     bbox: Optional[Polygon] = None,
-):
-    """Land GHG inventory vegetation land-flux zonal stats: gross emissions /
-    removals / net flux and area, grouped by ``land_state_class`` (tree loss /
-    tree gain / trees-remaining / non-trees-remaining) x year, rolled up to aoi_id.
-    Soil is a separate pipeline with its own output parquet. Results are QC'd
-    out-of-band against the reference dataset (see the QC notebook), not in-flow.
+) -> str:
+    """Land GHG inventory agriculture zonal stats: cropland + livestock emissions,
+    admin-only (no land_state_class, no year axis -- a single static snapshot),
+    rolled up to aoi_id.
 
     ``bbox`` clips the reduce to one area for a laptop-friendly local run; the
     result is written to a local parquet
-    (``admin-land_ghg_inventory-vegetation-{version}.parquet``) instead of the
+    (``admin-land_ghg_inventory-agriculture-{version}.parquet``) instead of the
     canonical global S3 path (which would be a partial write)."""
-    logging.getLogger("distributed.client").setLevel(logging.ERROR)
-
     if bbox is None:
         result_uri = (
-            f"s3://{ANALYTICS_BUCKET}/zonal-statistics/land_ghg_inventory-vegetation/"
-            f"{version}/admin-land_ghg_inventory-vegetation.parquet"
+            f"s3://{ANALYTICS_BUCKET}/zonal-statistics/land_ghg_inventory-agriculture/"
+            f"{version}/admin-land_ghg_inventory-agriculture.parquet"
         )
         if not overwrite and s3_uri_exists(result_uri):
             return result_uri
     else:
         # local bbox test run
-        result_uri = f"admin-land_ghg_inventory-vegetation-{version}.parquet"
+        result_uri = f"admin-land_ghg_inventory-agriculture-{version}.parquet"
 
-    result_df = _vegetation_result_df(bbox)
-
-    return common_tasks.save_result.with_options(name="land_ghg_inventory-save-result")(
-        result_df, result_uri
+    expected_groups = (
+        np.arange(gadm_country_code_count),
+        np.arange(gadm_region_code_count),
+        np.arange(gadm_subregion_code_count),
     )
+    datasets = land_ghg_inventory_tasks.load_agriculture.with_options(
+        name="land_ghg_inventory-agriculture-load-data"
+    )(
+        land_ghg_inventory_agriculture_zarr_uri,
+        country_zarr_uri,
+        region_zarr_uri,
+        subregion_zarr_uri,
+        bbox,
+    )
+    compute_input = land_ghg_inventory_tasks.setup_agriculture_compute.with_options(
+        name="set-up-land_ghg_inventory-agriculture-compute"
+    )(datasets, expected_groups)
+    reduced = common_tasks.compute_zonal_stat.with_options(
+        name="land_ghg_inventory-agriculture-compute-zonal-stats"
+    )(*compute_input, funcname="sum")
+    result_df = land_ghg_inventory_tasks.agriculture_result_dataframe.with_options(
+        name="land_ghg_inventory-agriculture-postprocess-result"
+    )(reduced)
+    return common_tasks.save_result.with_options(
+        name="land_ghg_inventory-agriculture-save-result"
+    )(result_df, result_uri)
+
+
+# component name -> its subflow. Add new components (e.g. soil) here to expose
+# them through `component`, without touching run_updates.py.
+COMPONENT_FLOWS = {
+    "vegetation": land_ghg_inventory_vegetation,
+    "agriculture": land_ghg_inventory_agriculture,
+}
+ALL_COMPONENTS = tuple(COMPONENT_FLOWS)
+
+
+@flow(name="Land GHG inventory area", retries=2, retry_delay_seconds=120)
+def land_ghg_inventory_area(
+    version: str,
+    overwrite: bool = False,
+    bbox: Optional[Polygon] = None,
+    component: Optional[str] = None,
+) -> list[str]:
+    """Land GHG inventory zonal stats, parent flow dispatching to the pipeline's
+    per-component subflows: vegetation (``land_ghg_inventory_vegetation``) and
+    agriculture (``land_ghg_inventory_agriculture``), each saved to its own
+    parquet. Results are QC'd out-of-band against the reference dataset (see the
+    QC notebook), not in-flow.
+
+    ``component`` selects a single subflow to run, e.g. ``"agriculture"``; unset
+    (the default) runs all components. An unknown name raises immediately."""
+    logging.getLogger("distributed.client").setLevel(logging.ERROR)
+
+    if component is not None:
+        if component not in COMPONENT_FLOWS:
+            raise ValueError(
+                f"Unknown land_ghg_inventory component: '{component}'. "
+                f"Accepted: {ALL_COMPONENTS}"
+            )
+        return [
+            COMPONENT_FLOWS[component](version=version, overwrite=overwrite, bbox=bbox)
+        ]
+
+    return [
+        flow_fn(version=version, overwrite=overwrite, bbox=bbox)
+        for flow_fn in COMPONENT_FLOWS.values()
+    ]

--- a/pipelines/land_ghg_inventory/prefect_flows/land_ghg_inventory_flow.py
+++ b/pipelines/land_ghg_inventory/prefect_flows/land_ghg_inventory_flow.py
@@ -11,7 +11,6 @@ from pipelines.globals import (
     gadm_country_code_count,
     gadm_region_code_count,
     gadm_subregion_code_count,
-    land_ghg_inventory_agriculture_zarr_uri,
     land_ghg_inventory_vegetation_zarr_uri,
     pixel_area_zarr_uri,
     region_zarr_uri,
@@ -113,10 +112,15 @@ def land_ghg_inventory_agriculture(
         np.arange(gadm_region_code_count),
         np.arange(gadm_subregion_code_count),
     )
+    agriculture_zarr_uri = (
+        land_ghg_inventory_tasks.prepare_agriculture_zarr.with_options(
+            name="land_ghg_inventory-agriculture-resample-source-zarr"
+        )(overwrite=overwrite)
+    )
     datasets = land_ghg_inventory_tasks.load_agriculture.with_options(
         name="land_ghg_inventory-agriculture-load-data"
     )(
-        land_ghg_inventory_agriculture_zarr_uri,
+        agriculture_zarr_uri,
         country_zarr_uri,
         region_zarr_uri,
         subregion_zarr_uri,

--- a/pipelines/land_ghg_inventory/prefect_flows/land_ghg_inventory_tasks.py
+++ b/pipelines/land_ghg_inventory/prefect_flows/land_ghg_inventory_tasks.py
@@ -5,7 +5,7 @@ import xarray as xr
 from prefect import task
 from shapely.geometry import Polygon
 
-from pipelines.land_ghg_inventory import stages
+from pipelines.land_ghg_inventory import agriculture_stages, vegetation_stages
 
 
 @task
@@ -17,16 +17,39 @@ def load_vegetation(
     subregion_uri: str,
     bbox: Optional[Polygon] = None,
 ) -> Tuple[xr.Dataset, xr.DataArray, xr.DataArray, xr.DataArray, xr.DataArray]:
-    return stages.load_data(
+    return vegetation_stages.load_data(
         vegetation_uri, pixel_area_uri, country_uri, region_uri, subregion_uri, bbox
     )
 
 
 @task
 def setup_vegetation_compute(datasets: Tuple, expected_groups: Tuple) -> Tuple:
-    return stages.setup_vegetation_compute(datasets, expected_groups)
+    return vegetation_stages.setup_vegetation_compute(datasets, expected_groups)
 
 
 @task
 def vegetation_result_dataframe(reduced: xr.DataArray) -> pd.DataFrame:
-    return stages.vegetation_result_dataframe(reduced)
+    return vegetation_stages.vegetation_result_dataframe(reduced)
+
+
+@task
+def load_agriculture(
+    agriculture_uri: str,
+    country_uri: str,
+    region_uri: str,
+    subregion_uri: str,
+    bbox: Optional[Polygon] = None,
+) -> Tuple[xr.Dataset, xr.DataArray, xr.DataArray, xr.DataArray]:
+    return agriculture_stages.load_agriculture(
+        agriculture_uri, country_uri, region_uri, subregion_uri, bbox
+    )
+
+
+@task
+def setup_agriculture_compute(datasets: Tuple, expected_groups: Tuple) -> Tuple:
+    return agriculture_stages.setup_agriculture_compute(datasets, expected_groups)
+
+
+@task
+def agriculture_result_dataframe(reduced: xr.DataArray) -> pd.DataFrame:
+    return agriculture_stages.agriculture_result_dataframe(reduced)

--- a/pipelines/land_ghg_inventory/prefect_flows/land_ghg_inventory_tasks.py
+++ b/pipelines/land_ghg_inventory/prefect_flows/land_ghg_inventory_tasks.py
@@ -6,6 +6,9 @@ from prefect import task
 from shapely.geometry import Polygon
 
 from pipelines.land_ghg_inventory import agriculture_stages, vegetation_stages
+from pipelines.land_ghg_inventory.create_agriculture_zarr import (
+    create_agriculture_zarr,
+)
 
 
 @task
@@ -30,6 +33,11 @@ def setup_vegetation_compute(datasets: Tuple, expected_groups: Tuple) -> Tuple:
 @task
 def vegetation_result_dataframe(reduced: xr.DataArray) -> pd.DataFrame:
     return vegetation_stages.vegetation_result_dataframe(reduced)
+
+
+@task
+def prepare_agriculture_zarr(overwrite: bool = False) -> str:
+    return create_agriculture_zarr(overwrite=overwrite)
 
 
 @task

--- a/pipelines/land_ghg_inventory/vegetation_stages.py
+++ b/pipelines/land_ghg_inventory/vegetation_stages.py
@@ -13,6 +13,7 @@ import pandas as pd
 import xarray as xr
 from shapely.geometry import Polygon
 
+from pipelines.land_ghg_inventory.common import align_to, clip
 from pipelines.land_ghg_inventory.land_state_categories import (
     LAND_STATE_TO_CATEGORY,
     VEGETATION_CATEGORIES,
@@ -110,22 +111,6 @@ def create_result_dataframe(
     return result
 
 
-def _align_to(reference: xr.Dataset, uri: str) -> xr.DataArray:
-    """Load a contextual band_data zarr and snap it to the reference grid."""
-    layer = _load_zarr(uri).band_data
-    if "band" in layer.dims:
-        layer = layer.isel(band=0, drop=True)
-    layer = layer.reindex_like(reference, method="nearest", tolerance=1e-4)
-    return xr.align(reference, layer, join="left")[1]
-
-
-def _clip(dataset: xr.Dataset, bbox: Optional[Polygon]) -> xr.Dataset:
-    if bbox is None:
-        return dataset
-    min_x, min_y, max_x, max_y = bbox.bounds
-    return dataset.sel(x=slice(min_x, max_x), y=slice(max_y, min_y))
-
-
 def collapse_land_state(land_state: xr.DataArray) -> xr.DataArray:
     """Relabel land_state_node codes to vegetation category codes (0-4).
 
@@ -158,14 +143,14 @@ def load_data(
     veg = _load_zarr(vegetation_uri)[
         list(VEGETATION_SOURCE_VARS.values()) + [LAND_STATE_VAR]
     ]
-    veg = _clip(veg, bbox)
+    veg = clip(veg, bbox)
     veg = veg.rename({source: name for name, source in VEGETATION_SOURCE_VARS.items()})
     return (
         veg,
-        _align_to(veg, pixel_area_uri),
-        _align_to(veg, country_uri),
-        _align_to(veg, region_uri),
-        _align_to(veg, subregion_uri),
+        align_to(veg, pixel_area_uri),
+        align_to(veg, country_uri),
+        align_to(veg, region_uri),
+        align_to(veg, subregion_uri),
     )
 
 

--- a/pipelines/land_ghg_inventory/vegetation_stages.py
+++ b/pipelines/land_ghg_inventory/vegetation_stages.py
@@ -4,6 +4,20 @@ Sums per-hectare fluxes (converted to per-pixel totals by multiplying by pixel a
 grouped by admin unit x land_state_class x year, then rolls up to aoi_id. The reduce
 and GADM roll-up are reused from ``pipelines.prefect_flows.common_stages``. Soil is a
 separate pipeline with its own output parquet.
+
+Output parquet schema (one row per aoi_id x land_state_class x year)::
+
+    aoi_id                     str    admin unit, e.g. "BRA", "BRA.1", "BRA.1.1"
+    aoi_type                   str    always "admin"
+    land_state_class           str    "tree_loss" | "tree_gain" |
+                                       "trees_remaining_trees" |
+                                       "non_trees_remaining_non_trees"
+                                       ("excluded" rows are dropped)
+    year                       int    calendar year, 2016-2024
+    gross_emissions_MgCO2e     float  summed gross emissions
+    gross_removals_MgCO2       float  summed gross removals
+    net_flux_MgCO2e            float  summed net flux (emissions - removals)
+    area_ha                    float  summed area, hectares
 """
 
 from typing import Dict, Optional, Tuple

--- a/pipelines/pyproject.toml
+++ b/pipelines/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "numba>=0.61.2",
     "numbagg",
     "numpy",
+    "odc-geo",
     "pandas",
     "pandera[pandas]",
     "prefect",

--- a/pipelines/run_updates.py
+++ b/pipelines/run_updates.py
@@ -87,15 +87,26 @@ def run_integrated_alerts_update(
     return result_uris
 
 
+# flow_name -> land_ghg_inventory component to run; None means "run all".
+LAND_GHG_INVENTORY_COMPONENT = {
+    "land_ghg_inventory_update": None,
+    "land_ghg_inventory_vegetation_update": "vegetation",
+    "land_ghg_inventory_agriculture_update": "agriculture",
+}
+
+
 @flow
 def run_land_ghg_inventory_update(
-    version, overwrite=False, is_latest=False, bbox=None
+    version, overwrite=False, is_latest=False, bbox=None, flow_name=None
 ) -> list[str]:
-    return [
-        land_ghg_inventory_flow.land_ghg_inventory_area(
-            version=version, overwrite=overwrite, bbox=bbox
-        )
-    ]
+    """Routes to the land_ghg_inventory component selected by `flow_name` (see
+    LAND_GHG_INVENTORY_COMPONENT); runs all components if unset."""
+    return land_ghg_inventory_flow.land_ghg_inventory_area(
+        version=version,
+        overwrite=overwrite,
+        bbox=bbox,
+        component=LAND_GHG_INVENTORY_COMPONENT.get(flow_name),
+    )
 
 
 def _parse_bbox(bbox):
@@ -111,6 +122,8 @@ class UpdateFlow(str, Enum):
     TCL_UPDATE = "tcl_update"
     INTEGRATED_ALERTS_UPDATE = "integrated_alerts_update"
     LAND_GHG_INVENTORY_UPDATE = "land_ghg_inventory_update"
+    LAND_GHG_INVENTORY_VEGETATION_UPDATE = "land_ghg_inventory_vegetation_update"
+    LAND_GHG_INVENTORY_AGRICULTURE_UPDATE = "land_ghg_inventory_agriculture_update"
 
 
 update_flows = {
@@ -118,10 +131,24 @@ update_flows = {
     UpdateFlow.TCL_UPDATE: run_tcl_update,
     UpdateFlow.INTEGRATED_ALERTS_UPDATE: run_integrated_alerts_update,
     UpdateFlow.LAND_GHG_INVENTORY_UPDATE: run_land_ghg_inventory_update,
+    UpdateFlow.LAND_GHG_INVENTORY_VEGETATION_UPDATE: run_land_ghg_inventory_update,
+    UpdateFlow.LAND_GHG_INVENTORY_AGRICULTURE_UPDATE: run_land_ghg_inventory_update,
 }
 
 # flows that produce versioned outputs and therefore require an explicit version
-VERSION_REQUIRED_FLOWS = (UpdateFlow.TCL_UPDATE, UpdateFlow.LAND_GHG_INVENTORY_UPDATE)
+VERSION_REQUIRED_FLOWS = (
+    UpdateFlow.TCL_UPDATE,
+    UpdateFlow.LAND_GHG_INVENTORY_UPDATE,
+    UpdateFlow.LAND_GHG_INVENTORY_VEGETATION_UPDATE,
+    UpdateFlow.LAND_GHG_INVENTORY_AGRICULTURE_UPDATE,
+)
+
+# flow_name values that route into run_land_ghg_inventory_update
+LAND_GHG_INVENTORY_FLOWS = (
+    UpdateFlow.LAND_GHG_INVENTORY_UPDATE,
+    UpdateFlow.LAND_GHG_INVENTORY_VEGETATION_UPDATE,
+    UpdateFlow.LAND_GHG_INVENTORY_AGRICULTURE_UPDATE,
+)
 
 
 def _validate_flow_args(flow_name: "UpdateFlow", version) -> None:
@@ -184,8 +211,9 @@ def run_updates(
             report = nullcontext()
 
         kwargs = dict(version=version, overwrite=overwrite, is_latest=is_latest)
-        if flow_name == UpdateFlow.LAND_GHG_INVENTORY_UPDATE:
+        if flow_name in LAND_GHG_INVENTORY_FLOWS:
             kwargs["bbox"] = bbox_geom
+            kwargs["flow_name"] = flow_name.value
         with report:
             result_uris = flow_fn(**kwargs)
 
@@ -216,9 +244,10 @@ def run_updates(
     "--bbox",
     default=None,
     help=(
-        "minx,miny,maxx,maxy to clip land_ghg_inventory_update to one area; "
-        "writes a local parquet instead of the global S3 path. "
-        "land_ghg_inventory_update only."
+        "minx,miny,maxx,maxy to clip the reduce to one area; writes a local "
+        "parquet instead of the global S3 path. Only applies to "
+        "land_ghg_inventory_update, land_ghg_inventory_vegetation_update, and "
+        "land_ghg_inventory_agriculture_update."
     ),
 )
 @click.option(

--- a/pipelines/run_updates.py
+++ b/pipelines/run_updates.py
@@ -101,6 +101,11 @@ def run_land_ghg_inventory_update(
 ) -> list[str]:
     """Routes to the land_ghg_inventory component selected by `flow_name` (see
     LAND_GHG_INVENTORY_COMPONENT); runs all components if unset."""
+    if flow_name is not None and flow_name not in LAND_GHG_INVENTORY_COMPONENT:
+        raise ValueError(
+            f"Unsupported land_ghg_inventory flow_name: '{flow_name}'. "
+            f"Accepted values: {list(LAND_GHG_INVENTORY_COMPONENT)}"
+        )
     return land_ghg_inventory_flow.land_ghg_inventory_area(
         version=version,
         overwrite=overwrite,

--- a/pipelines/run_updates.py
+++ b/pipelines/run_updates.py
@@ -215,7 +215,7 @@ def run_updates(
                 logger.warning("performance report skipped: no cluster (local run)")
             report = nullcontext()
 
-        kwargs = dict(version=version, overwrite=overwrite, is_latest=is_latest)
+        kwargs = {"version": version, "overwrite": overwrite, "is_latest": is_latest}
         if flow_name in LAND_GHG_INVENTORY_FLOWS:
             kwargs["bbox"] = bbox_geom
             kwargs["flow_name"] = flow_name.value

--- a/pipelines/test/integration/land_ghg_inventory/test_agriculture_flow.py
+++ b/pipelines/test/integration/land_ghg_inventory/test_agriculture_flow.py
@@ -1,0 +1,58 @@
+"""Integration test: the agriculture stages run against the real global zarr,
+clipped to São Tomé & Príncipe, must reproduce known reference totals. Exercises
+the same chain the flow runs (load -> setup -> reduce -> result dataframe), minus
+the global scope and the S3 write.
+"""
+
+import numpy as np
+import pytest
+from shapely.geometry import box
+
+from pipelines.globals import (
+    country_zarr_uri,
+    land_ghg_inventory_agriculture_zarr_uri,
+    region_zarr_uri,
+    subregion_zarr_uri,
+)
+from pipelines.land_ghg_inventory import agriculture_stages
+from pipelines.prefect_flows import common_stages
+
+# São Tomé & Príncipe: both islands, ocean elsewhere (isolated -> clean bbox).
+STP_BBOX = box(6.4, -0.05, 7.5, 1.8)
+
+# Reference totals for STP, computed directly against the real zarr (no reduce over
+# 999/86/854 admin codes changes these, since STP's own codes are within range).
+EXPECTED_TOTALS = {
+    "cropland_emissions": 2.279192e08,
+    "livestock_emissions": 1.382426e09,
+}
+
+
+def test_stp_reproduces_reference_totals():
+    datasets = agriculture_stages.load_agriculture(
+        land_ghg_inventory_agriculture_zarr_uri,
+        country_zarr_uri,
+        region_zarr_uri,
+        subregion_zarr_uri,
+        bbox=STP_BBOX,
+    )
+    expected_groups = (
+        np.arange(999),
+        np.arange(86),
+        np.arange(854),
+    )
+    cube, groupbys, out_expected_groups = agriculture_stages.setup_agriculture_compute(
+        datasets, expected_groups
+    )
+    reduced = common_stages.compute(cube, groupbys, out_expected_groups, "sum")
+    df = agriculture_stages.agriculture_result_dataframe(reduced)
+
+    country = df[(df["aoi_id"] == "STP")]
+    assert not country.empty
+    totals = country[["cropland_emissions", "livestock_emissions"]].sum()
+    assert totals["cropland_emissions"] == pytest.approx(
+        EXPECTED_TOTALS["cropland_emissions"], rel=0.02
+    )
+    assert totals["livestock_emissions"] == pytest.approx(
+        EXPECTED_TOTALS["livestock_emissions"], rel=0.02
+    )

--- a/pipelines/test/integration/land_ghg_inventory/test_agriculture_flow.py
+++ b/pipelines/test/integration/land_ghg_inventory/test_agriculture_flow.py
@@ -10,6 +10,9 @@ from shapely.geometry import box
 
 from pipelines.globals import (
     country_zarr_uri,
+    gadm_country_code_count,
+    gadm_region_code_count,
+    gadm_subregion_code_count,
     land_ghg_inventory_agriculture_zarr_uri,
     region_zarr_uri,
     subregion_zarr_uri,
@@ -21,7 +24,8 @@ from pipelines.prefect_flows import common_stages
 STP_BBOX = box(6.4, -0.05, 7.5, 1.8)
 
 # Reference totals for STP, computed directly against the real zarr (no reduce over
-# 999/86/854 admin codes changes these, since STP's own codes are within range).
+# the full gadm_*_code_count admin codes changes these, since STP's own codes are
+# within range).
 EXPECTED_TOTALS = {
     "cropland": 2.279192e08,
     "livestock": 1.382426e09,
@@ -37,9 +41,9 @@ def test_stp_reproduces_reference_totals():
         bbox=STP_BBOX,
     )
     expected_groups = (
-        np.arange(999),
-        np.arange(86),
-        np.arange(854),
+        np.arange(gadm_country_code_count),
+        np.arange(gadm_region_code_count),
+        np.arange(gadm_subregion_code_count),
     )
     cube, groupbys, out_expected_groups = agriculture_stages.setup_agriculture_compute(
         datasets, expected_groups

--- a/pipelines/test/integration/land_ghg_inventory/test_agriculture_flow.py
+++ b/pipelines/test/integration/land_ghg_inventory/test_agriculture_flow.py
@@ -23,8 +23,8 @@ STP_BBOX = box(6.4, -0.05, 7.5, 1.8)
 # Reference totals for STP, computed directly against the real zarr (no reduce over
 # 999/86/854 admin codes changes these, since STP's own codes are within range).
 EXPECTED_TOTALS = {
-    "cropland_emissions": 2.279192e08,
-    "livestock_emissions": 1.382426e09,
+    "cropland": 2.279192e08,
+    "livestock": 1.382426e09,
 }
 
 
@@ -47,12 +47,8 @@ def test_stp_reproduces_reference_totals():
     reduced = common_stages.compute(cube, groupbys, out_expected_groups, "sum")
     df = agriculture_stages.agriculture_result_dataframe(reduced)
 
-    country = df[(df["aoi_id"] == "STP")]
+    country = df[df["aoi_id"] == "STP"]
     assert not country.empty
-    totals = country[["cropland_emissions", "livestock_emissions"]].sum()
-    assert totals["cropland_emissions"] == pytest.approx(
-        EXPECTED_TOTALS["cropland_emissions"], rel=0.02
-    )
-    assert totals["livestock_emissions"] == pytest.approx(
-        EXPECTED_TOTALS["livestock_emissions"], rel=0.02
-    )
+    totals = country.groupby("category")["gross_emissions_MgCO2e"].sum()
+    assert totals["cropland"] == pytest.approx(EXPECTED_TOTALS["cropland"], rel=0.02)
+    assert totals["livestock"] == pytest.approx(EXPECTED_TOTALS["livestock"], rel=0.02)

--- a/pipelines/test/integration/land_ghg_inventory/test_land_ghg_inventory_flow.py
+++ b/pipelines/test/integration/land_ghg_inventory/test_land_ghg_inventory_flow.py
@@ -15,7 +15,7 @@ from pipelines.globals import (
     region_zarr_uri,
     subregion_zarr_uri,
 )
-from pipelines.land_ghg_inventory import stages
+from pipelines.land_ghg_inventory import vegetation_stages
 from pipelines.prefect_flows import common_stages
 
 # São Tomé & Príncipe: both islands, ocean elsewhere (isolated -> clean bbox).
@@ -30,7 +30,7 @@ EXPECTED_TOTALS = {
 
 
 def test_stp_reproduces_reference_totals():
-    datasets = stages.load_data(
+    datasets = vegetation_stages.load_data(
         land_ghg_inventory_vegetation_zarr_uri,
         pixel_area_zarr_uri,
         country_zarr_uri,
@@ -45,11 +45,11 @@ def test_stp_reproduces_reference_totals():
         np.array([0, 1, 2, 3, 4]),
         np.arange(9),
     )
-    cube, groupbys, out_expected_groups = stages.setup_vegetation_compute(
+    cube, groupbys, out_expected_groups = vegetation_stages.setup_vegetation_compute(
         datasets, expected_groups
     )
     reduced = common_stages.compute(cube, groupbys, out_expected_groups, "sum")
-    df = stages.vegetation_result_dataframe(reduced)
+    df = vegetation_stages.vegetation_result_dataframe(reduced)
 
     country = df[(df["aoi_id"] == "STP")]
     assert not country.empty

--- a/pipelines/test/unit/land_ghg_inventory/conftest.py
+++ b/pipelines/test/unit/land_ghg_inventory/conftest.py
@@ -71,7 +71,7 @@ def synthetic_agriculture_datasets():
 
     Agriculture values are already per-pixel absolute totals (no pixel-area
     multiplication, no year/land_state axis). Per-pixel totals are known:
-    cropland_emissions=[[10, 20], [30, 0]], livestock_emissions=[[1, 2], [3, 0]].
+    cropland=[[10, 20], [30, 0]], livestock=[[1, 2], [3, 0]].
     """
     coords2 = {"y": [0.0, 1.0], "x": [0.0, 1.0]}
 
@@ -84,8 +84,8 @@ def synthetic_agriculture_datasets():
 
     ag = xr.Dataset(
         {
-            "cropland_emissions": layer([[10.0, 20.0], [30.0, 0.0]]),
-            "livestock_emissions": layer([[1.0, 2.0], [3.0, 0.0]]),
+            "cropland": layer([[10.0, 20.0], [30.0, 0.0]]),
+            "livestock": layer([[1.0, 2.0], [3.0, 0.0]]),
         }
     )
 

--- a/pipelines/test/unit/land_ghg_inventory/conftest.py
+++ b/pipelines/test/unit/land_ghg_inventory/conftest.py
@@ -63,3 +63,42 @@ def synthetic_datasets():
         np.array([0, 1]),
     )
     return datasets, expected_groups
+
+
+@pytest.fixture
+def synthetic_agriculture_datasets():
+    """Tiny 2x2 scene, two admin units (BRA subregion 1 and BRA country-only).
+
+    Agriculture values are already per-pixel absolute totals (no pixel-area
+    multiplication, no year/land_state axis). Per-pixel totals are known:
+    cropland_emissions=[[10, 20], [30, 0]], livestock_emissions=[[1, 2], [3, 0]].
+    """
+    coords2 = {"y": [0.0, 1.0], "x": [0.0, 1.0]}
+
+    def layer(values, dtype="float32"):
+        return xr.DataArray(
+            da.from_array(np.array(values, dtype=dtype), chunks=(2, 2)),
+            dims=["y", "x"],
+            coords=coords2,
+        )
+
+    ag = xr.Dataset(
+        {
+            "cropland_emissions": layer([[10.0, 20.0], [30.0, 0.0]]),
+            "livestock_emissions": layer([[1.0, 2.0], [3.0, 0.0]]),
+        }
+    )
+
+    # top row -> BRA subregion 1; bottom-left -> BRA subregion 0 (region-only);
+    # bottom-right -> no country (dropped, like ocean pixels).
+    country = layer([[76, 76], [76, 0]], "int32")
+    region = layer([[1, 1], [1, 0]], "int32")
+    subregion = layer([[1, 1], [0, 0]], "int32")
+
+    datasets = (ag, country, region, subregion)
+    expected_groups = (
+        np.array([76]),
+        np.array([1]),
+        np.array([0, 1]),
+    )
+    return datasets, expected_groups

--- a/pipelines/test/unit/land_ghg_inventory/test_agriculture_result_dataframe.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_agriculture_result_dataframe.py
@@ -1,0 +1,31 @@
+from pipelines.land_ghg_inventory import agriculture_stages
+from pipelines.prefect_flows import common_stages
+
+
+def test_agriculture_result_dataframe_rolls_up(synthetic_agriculture_datasets):
+    datasets, expected_groups = synthetic_agriculture_datasets
+
+    cube, groupbys, out_expected_groups = agriculture_stages.setup_agriculture_compute(
+        datasets, expected_groups
+    )
+    reduced = common_stages.compute(cube, groupbys, out_expected_groups, "sum")
+    df = agriculture_stages.agriculture_result_dataframe(reduced)
+
+    assert {
+        "aoi_id",
+        "aoi_type",
+        "cropland_emissions",
+        "livestock_emissions",
+    }.issubset(df.columns)
+    assert "land_state_class" not in df.columns
+    assert "year" not in df.columns
+
+    # subregion-level totals: top row pixels (10+20, 1+2)
+    subregion_row = df[df.aoi_id == "BRA.1.1"].iloc[0]
+    assert subregion_row.cropland_emissions == 30.0
+    assert subregion_row.livestock_emissions == 3.0
+
+    # country-level roll-up: subregion (30, 3) + region-only bottom-left pixel (30, 3)
+    country_row = df[df.aoi_id == "BRA"].iloc[0]
+    assert country_row.cropland_emissions == 60.0
+    assert country_row.livestock_emissions == 6.0

--- a/pipelines/test/unit/land_ghg_inventory/test_agriculture_result_dataframe.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_agriculture_result_dataframe.py
@@ -14,18 +14,25 @@ def test_agriculture_result_dataframe_rolls_up(synthetic_agriculture_datasets):
     assert {
         "aoi_id",
         "aoi_type",
-        "cropland_emissions",
-        "livestock_emissions",
+        "category",
+        "gross_emissions_MgCO2e",
     }.issubset(df.columns)
     assert "land_state_class" not in df.columns
     assert "year" not in df.columns
+    assert set(df["category"]) == {"cropland", "livestock"}
 
-    # subregion-level totals: top row pixels (10+20, 1+2)
-    subregion_row = df[df.aoi_id == "BRA.1.1"].iloc[0]
-    assert subregion_row.cropland_emissions == 30.0
-    assert subregion_row.livestock_emissions == 3.0
+    # subregion-level totals: top row pixels (10+20, 1+2), one row per
+    # category
+    subregion_rows = df[df.aoi_id == "BRA.1.1"]
+    cropland_row = subregion_rows[subregion_rows.category == "cropland"].iloc[0]
+    assert cropland_row.gross_emissions_MgCO2e == 30.0
+    livestock_row = subregion_rows[subregion_rows.category == "livestock"].iloc[0]
+    assert livestock_row.gross_emissions_MgCO2e == 3.0
 
-    # country-level roll-up: subregion (30, 3) + region-only bottom-left pixel (30, 3)
-    country_row = df[df.aoi_id == "BRA"].iloc[0]
-    assert country_row.cropland_emissions == 60.0
-    assert country_row.livestock_emissions == 6.0
+    # country-level roll-up: subregion (30, 3) + region-only bottom-left
+    # pixel (30, 3)
+    country_rows = df[df.aoi_id == "BRA"]
+    cropland_country = country_rows[country_rows.category == "cropland"].iloc[0]
+    assert cropland_country.gross_emissions_MgCO2e == 60.0
+    livestock_country = country_rows[country_rows.category == "livestock"].iloc[0]
+    assert livestock_country.gross_emissions_MgCO2e == 6.0

--- a/pipelines/test/unit/land_ghg_inventory/test_agriculture_setup_compute.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_agriculture_setup_compute.py
@@ -10,14 +10,11 @@ def test_setup_agriculture_compute_builds_measure_cube_and_groupbys(
         datasets, expected_groups
     )
 
-    assert list(cube.analysis_layer.values) == [
-        "cropland_emissions",
-        "livestock_emissions",
-    ]
+    assert list(cube.category.values) == ["cropland", "livestock"]
     # values pass through unchanged (already per-pixel absolute totals)
-    cropland = cube.sel(analysis_layer="cropland_emissions").values
+    cropland = cube.sel(category="cropland").values
     assert (cropland == [[10.0, 20.0], [30.0, 0.0]]).all()
-    livestock = cube.sel(analysis_layer="livestock_emissions").values
+    livestock = cube.sel(category="livestock").values
     assert (livestock == [[1.0, 2.0], [3.0, 0.0]]).all()
 
     assert [g.name for g in groupbys] == ["country", "region", "subregion"]

--- a/pipelines/test/unit/land_ghg_inventory/test_agriculture_setup_compute.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_agriculture_setup_compute.py
@@ -1,0 +1,24 @@
+from pipelines.land_ghg_inventory import agriculture_stages
+
+
+def test_setup_agriculture_compute_builds_measure_cube_and_groupbys(
+    synthetic_agriculture_datasets,
+):
+    datasets, expected_groups = synthetic_agriculture_datasets
+
+    cube, groupbys, out_expected_groups = agriculture_stages.setup_agriculture_compute(
+        datasets, expected_groups
+    )
+
+    assert list(cube.analysis_layer.values) == [
+        "cropland_emissions",
+        "livestock_emissions",
+    ]
+    # values pass through unchanged (already per-pixel absolute totals)
+    cropland = cube.sel(analysis_layer="cropland_emissions").values
+    assert (cropland == [[10.0, 20.0], [30.0, 0.0]]).all()
+    livestock = cube.sel(analysis_layer="livestock_emissions").values
+    assert (livestock == [[1.0, 2.0], [3.0, 0.0]]).all()
+
+    assert [g.name for g in groupbys] == ["country", "region", "subregion"]
+    assert out_expected_groups is expected_groups

--- a/pipelines/test/unit/land_ghg_inventory/test_create_agriculture_zarr.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_create_agriculture_zarr.py
@@ -1,0 +1,110 @@
+from unittest.mock import patch
+
+import dask.array as da
+import numpy as np
+import pytest
+import xarray as xr
+
+from pipelines.globals import land_ghg_inventory_agriculture_zarr_uri
+from pipelines.land_ghg_inventory import create_agriculture_zarr as mod
+from pipelines.land_ghg_inventory.agriculture_stages import AGRICULTURE_SOURCE_VARS
+
+
+@pytest.fixture
+def reference_veg_dataset():
+    """4x4 vegetation grid, 2 years -- only used for its geobox."""
+    ref = xr.DataArray(
+        da.from_array(np.zeros((2, 4, 4), dtype="float32"), chunks=(1, 4, 4)),
+        dims=["year", "y", "x"],
+        coords={
+            "year": [0, 1],
+            "y": [1.0, 0.5, 0.0, -0.5],
+            "x": [0.0, 0.5, 1.0, 1.5],
+        },
+    )
+    return xr.Dataset({mod.REFERENCE_GRID_VAR: ref})
+
+
+def _fake_cog(value):
+    """A coarser source raster (kg), band dim included like a real GeoTIFF read."""
+    arr = xr.DataArray(
+        da.from_array(np.full((1, 2, 2), value, dtype="float32"), chunks=(1, 2, 2)),
+        dims=["band", "y", "x"],
+        coords={"band": [1], "y": [1.0, 0.0], "x": [0.0, 1.0]},
+    )
+    arr.rio.write_crs("EPSG:4326", inplace=True)
+    return arr
+
+
+def test_create_agriculture_zarr_writes_expected_shape(reference_veg_dataset):
+    captured = {}
+
+    def fake_to_zarr(self, uri, group=None, mode=None):
+        captured["ds"] = self
+        captured["uri"] = uri
+        captured["group"] = group
+        captured["mode"] = mode
+
+    with (
+        patch.object(mod, "s3_uri_exists", return_value=False),
+        patch.object(mod.xr, "open_zarr", return_value=reference_veg_dataset),
+        patch.object(
+            mod.rio,
+            "open_rasterio",
+            side_effect=[_fake_cog(10_000.0), _fake_cog(2_000.0)],
+        ),
+        patch.object(xr.Dataset, "to_zarr", fake_to_zarr),
+    ):
+        result_uri = mod.create_agriculture_zarr(overwrite=False)
+
+    assert result_uri == land_ghg_inventory_agriculture_zarr_uri
+    assert captured["uri"] == land_ghg_inventory_agriculture_zarr_uri
+    assert captured["group"] == "pipeline"
+    assert captured["mode"] == "w"
+
+    ds = captured["ds"].compute()
+    # matches what agriculture_stages.load_agriculture expects: only these two
+    # variables, dims (y, x) with no leftover band dim.
+    assert set(ds.data_vars) == set(AGRICULTURE_SOURCE_VARS.values())
+    assert ds.sizes.keys() == {"y", "x"}
+    assert "band" not in ds.dims
+
+    # resampled onto the reference (vegetation) grid, not the source grid
+    assert list(ds.y.values) == [1.0, 0.5, 0.0, -0.5]
+    assert list(ds.x.values) == [0.0, 0.5, 1.0, 1.5]
+
+    # kg -> Mg conversion applied
+    cropland = ds[AGRICULTURE_SOURCE_VARS["cropland"]].values
+    livestock = ds[AGRICULTURE_SOURCE_VARS["livestock"]].values
+    assert cropland[0, 0] == pytest.approx(10.0)
+    assert livestock[0, 0] == pytest.approx(2.0)
+
+
+def test_create_agriculture_zarr_skips_when_present_and_not_overwrite():
+    with (
+        patch.object(mod, "s3_uri_exists", return_value=True) as mock_exists,
+        patch.object(mod, "_reference_geobox") as mock_geobox,
+    ):
+        result_uri = mod.create_agriculture_zarr(overwrite=False)
+
+    assert result_uri == land_ghg_inventory_agriculture_zarr_uri
+    mock_exists.assert_called_once_with(
+        f"{land_ghg_inventory_agriculture_zarr_uri}/pipeline/zarr.json"
+    )
+    mock_geobox.assert_not_called()
+
+
+def test_create_agriculture_zarr_overwrite_skips_exists_check(reference_veg_dataset):
+    with (
+        patch.object(mod, "s3_uri_exists") as mock_exists,
+        patch.object(mod.xr, "open_zarr", return_value=reference_veg_dataset),
+        patch.object(
+            mod.rio,
+            "open_rasterio",
+            side_effect=[_fake_cog(1_000.0), _fake_cog(1_000.0)],
+        ),
+        patch.object(xr.Dataset, "to_zarr"),
+    ):
+        mod.create_agriculture_zarr(overwrite=True)
+
+    mock_exists.assert_not_called()

--- a/pipelines/test/unit/land_ghg_inventory/test_vegetation_result_dataframe.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_vegetation_result_dataframe.py
@@ -2,18 +2,18 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
-from pipelines.land_ghg_inventory import stages
+from pipelines.land_ghg_inventory import vegetation_stages
 from pipelines.prefect_flows import common_stages
 
 
 def test_result_dataframe_rolls_up_and_maps(synthetic_datasets):
     datasets, expected_groups = synthetic_datasets
 
-    cube, groupbys, out_expected_groups = stages.setup_vegetation_compute(
+    cube, groupbys, out_expected_groups = vegetation_stages.setup_vegetation_compute(
         datasets, expected_groups
     )
     reduced = common_stages.compute(cube, groupbys, out_expected_groups, "sum")
-    df = stages.vegetation_result_dataframe(reduced)
+    df = vegetation_stages.vegetation_result_dataframe(reduced)
 
     assert {
         "aoi_id",
@@ -105,11 +105,11 @@ def test_structurally_zero_measure_is_zero_not_nan():
         np.array([0, 1, 2, 3, 4]),
         np.array([0]),
     )
-    cube, groupbys, out_expected_groups = stages.setup_vegetation_compute(
+    cube, groupbys, out_expected_groups = vegetation_stages.setup_vegetation_compute(
         datasets, expected_groups
     )
     reduced = common_stages.compute(cube, groupbys, out_expected_groups, "sum")
-    df = stages.vegetation_result_dataframe(reduced)
+    df = vegetation_stages.vegetation_result_dataframe(reduced)
 
     measures = ["gross_emissions_MgCO2e", "gross_removals_MgCO2", "net_flux_MgCO2e"]
     assert df[measures + ["area_ha"]].notna().all().all()

--- a/pipelines/test/unit/land_ghg_inventory/test_vegetation_setup_compute.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_vegetation_setup_compute.py
@@ -1,10 +1,10 @@
-from pipelines.land_ghg_inventory import stages
+from pipelines.land_ghg_inventory import vegetation_stages
 
 
 def test_setup_compute_builds_flux_cube_and_groupbys(synthetic_datasets):
     datasets, expected_groups = synthetic_datasets
 
-    cube, groupbys, out_expected_groups = stages.setup_vegetation_compute(
+    cube, groupbys, out_expected_groups = vegetation_stages.setup_vegetation_compute(
         datasets, expected_groups
     )
 

--- a/pipelines/test/unit/test_run_updates.py
+++ b/pipelines/test/unit/test_run_updates.py
@@ -2,7 +2,12 @@ import pytest
 
 from pipelines.globals import gadm_country_code_count
 from pipelines.prefect_flows.common_stages import numeric_to_alpha3
-from pipelines.run_updates import UpdateFlow, _parse_bbox, _validate_flow_args
+from pipelines.run_updates import (
+    VERSION_REQUIRED_FLOWS,
+    UpdateFlow,
+    _parse_bbox,
+    _validate_flow_args,
+)
 
 
 def test_parse_bbox_parses_minx_miny_maxx_maxy():
@@ -19,17 +24,19 @@ def test_parse_bbox_rejects_wrong_coordinate_count():
         _parse_bbox("-74,-11.2,-66.5")
 
 
-@pytest.mark.parametrize(
-    "flow_name",
-    [UpdateFlow.TCL_UPDATE, UpdateFlow.LAND_GHG_INVENTORY_UPDATE],
-)
+@pytest.mark.parametrize("flow_name", VERSION_REQUIRED_FLOWS, ids=lambda f: f.value)
 def test_version_required_for_versioned_flows(flow_name):
     with pytest.raises(ValueError):
         _validate_flow_args(flow_name, version=None)
 
 
-def test_version_not_required_for_dist_update():
-    _validate_flow_args(UpdateFlow.DIST_UPDATE, version=None)  # must not raise
+@pytest.mark.parametrize(
+    "flow_name",
+    [f for f in UpdateFlow if f not in VERSION_REQUIRED_FLOWS],
+    ids=lambda f: f.value,
+)
+def test_version_not_required_for_unversioned_flows(flow_name):
+    _validate_flow_args(flow_name, version=None)  # must not raise
 
 
 def test_country_expected_groups_covers_every_iso_code():

--- a/pipelines/uv.lock
+++ b/pipelines/uv.lock
@@ -2033,6 +2033,23 @@ wheels = [
 ]
 
 [[package]]
+name = "odc-geo"
+version = "0.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "affine" },
+    { name = "cachetools" },
+    { name = "numpy" },
+    { name = "pyproj" },
+    { name = "shapely" },
+    { name = "xarray" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/7d/409d01745f55e2577fc8a397fd3c54207be65ef95a99a79ca512c42c473b/odc_geo-0.5.3.tar.gz", hash = "sha256:57aca2e894b8d8e82aa2e2f607630bb33e2b480f68077b52c273ff2b8367dfc7", size = 144174, upload-time = "2026-07-16T22:09:08.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/db/cbb4bfa7bb7a1b91f8be7964b2477730d86516756afddaa79cd8683a30d8/odc_geo-0.5.3-py3-none-any.whl", hash = "sha256:5d22c7933a45653d7d0d9b4ead92579bf8bec627d6a3d4bf7e13d77b786e3662", size = 159610, upload-time = "2026-07-16T22:09:07.39Z" },
+]
+
+[[package]]
 name = "opentelemetry-api"
 version = "1.34.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3924,6 +3941,7 @@ dependencies = [
     { name = "numba" },
     { name = "numbagg" },
     { name = "numpy" },
+    { name = "odc-geo" },
     { name = "pandas" },
     { name = "pandera", extra = ["pandas"] },
     { name = "prefect" },
@@ -3961,6 +3979,7 @@ requires-dist = [
     { name = "numba", specifier = ">=0.61.2" },
     { name = "numbagg" },
     { name = "numpy" },
+    { name = "odc-geo" },
     { name = "pandas" },
     { name = "pandera", extras = ["pandas"] },
     { name = "prefect" },

--- a/terraform/prefect.tf
+++ b/terraform/prefect.tf
@@ -160,7 +160,7 @@ resource "prefect_deployment" "gnw_zonal_stats_update" {
         title   = "Flow Name"
         type    = "string"
         default = "dist_update"
-        enum    = ["dist_update", "tcl_update", "integrated_alerts_update", "land_ghg_inventory_update"]
+        enum    = ["dist_update", "tcl_update", "integrated_alerts_update", "land_ghg_inventory_update", "land_ghg_inventory_vegetation_update", "land_ghg_inventory_agriculture_update"]
       }
     }
   })


### PR DESCRIPTION
## Summary
- Add the Land GHG inventory **agriculture** component (`land_ghg_inventory_agriculture` flow): cropland + livestock emissions, admin-only zonal stats (no `land_state_class` or year axis — a single static snapshot), rolled up to `aoi_id`.
- Refactor the existing vegetation logic out of the old combined `land_ghg_inventory_area` flow into its own `land_ghg_inventory_vegetation` subflow (renamed `stages.py` → `vegetation_stages.py`), so `land_ghg_inventory_area` is now a thin parent that dispatches to per-component subflows (`vegetation`, `agriculture`) via a `component` arg, each writing its own parquet.
- Wire the new component through to Prefect Cloud: `run_updates.py` gains `land_ghg_inventory_vegetation_update` and `land_ghg_inventory_agriculture_update` as selectable `UpdateFlow` entries (in addition to `land_ghg_inventory_update`, which still runs all components).


### Output schemas

Also documented inline in `agriculture_stages.py` / `vegetation_stages.py`.

**Agriculture** — one row per `aoi_id` x `category`:

| column | type | notes |
|---|---|---|
| `aoi_id` | str | admin unit, e.g. `"BRA"`, `"BRA.1"`, `"BRA.1.1"` |
| `aoi_type` | str | always `"admin"` |
| `category` | str | `"cropland"` \| `"livestock"` |
| `gross_emissions_MgCO2e` | float | summed emissions for `aoi_id` x `category` |

