### PR TITLE
Authenticate GHG endpoint

### DIFF
--- a/api/app/authentication.py
+++ b/api/app/authentication.py
@@ -5,18 +5,25 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from app.infrastructure.external_services.resource_watch_authenticator import (
     ResourceWatchAuthenticator,
+    TokenValidationCache,
     UpstreamAuthError,
 )
 from app.models.common.authentication import User
 
 bearer_scheme = HTTPBearer(auto_error=False)
 
+# Shared across the per-request authenticators built by get_authenticator, so a
+# token is validated against RW at most once per TTL rather than on every request
+# and every LRO poll.
+token_validation_cache = TokenValidationCache()
+
 
 def get_authenticator() -> ResourceWatchAuthenticator:
     """Edge-injected authenticator. Reads the RW API base from the environment so
     it can be pointed at staging without code changes; defaults to production."""
     return ResourceWatchAuthenticator(
-        api_url=os.getenv("RW_API_URL", "https://api.resourcewatch.org")
+        api_url=os.getenv("RW_API_URL", "https://api.resourcewatch.org"),
+        cache=token_validation_cache,
     )
 
 

--- a/api/app/authentication.py
+++ b/api/app/authentication.py
@@ -1,0 +1,53 @@
+import os
+
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from app.infrastructure.external_services.resource_watch_authenticator import (
+    ResourceWatchAuthenticator,
+    UpstreamAuthError,
+)
+from app.models.common.authentication import User
+
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def get_authenticator() -> ResourceWatchAuthenticator:
+    """Edge-injected authenticator. Reads the RW API base from the environment so
+    it can be pointed at staging without code changes; defaults to production."""
+    return ResourceWatchAuthenticator(
+        api_url=os.getenv("RW_API_URL", "https://api.resourcewatch.org")
+    )
+
+
+async def require_resource_watch_admin(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+    authenticator: ResourceWatchAuthenticator = Depends(get_authenticator),
+) -> User:
+    """Guard that only lets ResourceWatch admins through.
+
+    401 when the token is missing or invalid; 403 when the token is valid but the
+    user is not an admin.
+    """
+    if credentials is None:
+        raise HTTPException(
+            status_code=401,
+            detail="Missing bearer token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    try:
+        user = await authenticator.get_user(credentials.credentials)
+    except UpstreamAuthError:
+        raise HTTPException(
+            status_code=502, detail="Could not reach the authorization server"
+        )
+
+    if user is None:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+    if user.role != "ADMIN":
+        raise HTTPException(
+            status_code=403, detail="Requires a ResourceWatch admin account"
+        )
+
+    return user

--- a/api/app/infrastructure/external_services/resource_watch_authenticator.py
+++ b/api/app/infrastructure/external_services/resource_watch_authenticator.py
@@ -1,0 +1,55 @@
+from typing import Callable, Optional
+
+import httpx
+
+from app.models.common.authentication import User
+
+
+class UpstreamAuthError(Exception):
+    """The authorization server could not be reached or gave an unusable
+    response, so no authentication decision can be made."""
+
+
+class ResourceWatchAuthenticator:
+    """Validates a ResourceWatch bearer token against the RW API.
+
+    Mirrors gfw-data-api's ``who_am_i``: a GET to ``/auth/check-logged`` with the
+    token as a bearer credential. Pure infrastructure -- it resolves identity, it
+    does not decide authorization (that policy lives at the edge).
+    """
+
+    def __init__(
+        self,
+        api_url: str,
+        timeout_seconds: float = 10.0,
+        client_factory: Callable[[], httpx.AsyncClient] = httpx.AsyncClient,
+    ):
+        self.api_url = api_url.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+        self.client_factory = client_factory
+
+    async def get_user(self, token: str) -> Optional[User]:
+        """Return the authenticated user, or ``None`` if the token is invalid or
+        expired. Raises ``UpstreamAuthError`` if the RW API is unreachable or
+        returns an unexpected status."""
+        headers = {"Authorization": f"Bearer {token}"}
+        url = f"{self.api_url}/auth/check-logged"
+
+        try:
+            async with self.client_factory() as client:
+                response = await client.get(
+                    url, headers=headers, timeout=self.timeout_seconds
+                )
+        except httpx.HTTPError as error:
+            raise UpstreamAuthError(
+                "Call to the authorization server failed"
+            ) from error
+
+        if response.status_code == 401:
+            return None
+        if response.status_code != 200:
+            raise UpstreamAuthError(
+                "Authorization server responded with " f"status {response.status_code}"
+            )
+
+        return User(**response.json())

--- a/api/app/infrastructure/external_services/resource_watch_authenticator.py
+++ b/api/app/infrastructure/external_services/resource_watch_authenticator.py
@@ -1,4 +1,5 @@
-from typing import Callable, Optional
+import time
+from typing import Callable, Dict, Optional, Tuple
 
 import httpx
 
@@ -8,6 +9,43 @@ from app.models.common.authentication import User
 class UpstreamAuthError(Exception):
     """The authorization server could not be reached or gave an unusable
     response, so no authentication decision can be made."""
+
+
+class TokenValidationCache:
+    """A short-lived TTL cache of token -> resolved identity.
+
+    Caches negative results (``None``) too, so a flood of invalid tokens cannot
+    hammer the authorization server. The TTL bounds how long a revoked token
+    keeps working, so keep it short.
+    """
+
+    def __init__(
+        self,
+        ttl_seconds: float = 120.0,
+        max_size: int = 1024,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self.ttl_seconds = ttl_seconds
+        self.max_size = max_size
+        self.clock = clock
+        self.entries: Dict[str, Tuple[float, Optional[User]]] = {}
+
+    def get(self, token: str) -> Tuple[bool, Optional[User]]:
+        """Return ``(hit, user)``. ``hit`` distinguishes a cached ``None`` from a
+        miss."""
+        entry = self.entries.get(token)
+        if entry is None:
+            return False, None
+        expires_at, user = entry
+        if self.clock() >= expires_at:
+            del self.entries[token]
+            return False, None
+        return True, user
+
+    def set(self, token: str, user: Optional[User]) -> None:
+        if len(self.entries) >= self.max_size:
+            self.entries.clear()  # crude but bounded; avoids unbounded growth
+        self.entries[token] = (self.clock() + self.ttl_seconds, user)
 
 
 class ResourceWatchAuthenticator:
@@ -23,15 +61,32 @@ class ResourceWatchAuthenticator:
         api_url: str,
         timeout_seconds: float = 10.0,
         client_factory: Callable[[], httpx.AsyncClient] = httpx.AsyncClient,
+        cache: Optional[TokenValidationCache] = None,
     ):
         self.api_url = api_url.rstrip("/")
         self.timeout_seconds = timeout_seconds
         self.client_factory = client_factory
+        self.cache = cache
 
     async def get_user(self, token: str) -> Optional[User]:
         """Return the authenticated user, or ``None`` if the token is invalid or
         expired. Raises ``UpstreamAuthError`` if the RW API is unreachable or
-        returns an unexpected status."""
+        returns an unexpected status.
+
+        Successful decisions (a user or ``None``) are cached; upstream failures
+        are not, so a transient RW blip does not stick."""
+        if self.cache is not None:
+            hit, cached_user = self.cache.get(token)
+            if hit:
+                return cached_user
+
+        user = await self._fetch_user(token)
+
+        if self.cache is not None:
+            self.cache.set(token, user)
+        return user
+
+    async def _fetch_user(self, token: str) -> Optional[User]:
         headers = {"Authorization": f"Bearer {token}"}
         url = f"{self.api_url}/auth/check-logged"
 

--- a/api/app/models/common/authentication.py
+++ b/api/app/models/common/authentication.py
@@ -1,0 +1,17 @@
+from typing import Any, Dict
+
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    """A ResourceWatch user as returned by the RW API's check-logged endpoint.
+
+    Only the fields we authorize on are declared; RW returns more (email,
+    provider, createdAt, ...) which are ignored.
+    """
+
+    id: str
+    role: str
+    extraUserData: Dict[str, Any] = {}
+
+    model_config = {"extra": "ignore"}

--- a/api/app/routers/land_change/land_ghg_inventory/land_ghg_inventory.py
+++ b/api/app/routers/land_change/land_ghg_inventory/land_ghg_inventory.py
@@ -3,6 +3,7 @@ from fastapi import Response as FastAPIResponse
 from fastapi.responses import ORJSONResponse
 from pydantic import UUID5
 
+from app.authentication import require_resource_watch_admin
 from app.dependencies import get_environment
 from app.domain.analyzers.land_ghg_inventory_analyzer import (
     INPUT_URIS,
@@ -27,7 +28,12 @@ from app.models.land_change.land_ghg_inventory import (
 from app.routers.common_analytics import create_analysis, get_analysis
 from app.use_cases.analysis.analysis_service import AnalysisService
 
-router = APIRouter(prefix=f"/{ANALYTICS_NAME}")
+# ResourceWatch admin only: gates both the analysis-creating POST and the
+# result-polling GET on this router.
+router = APIRouter(
+    prefix=f"/{ANALYTICS_NAME}",
+    dependencies=[Depends(require_resource_watch_admin)],
+)
 
 
 def get_analysis_repository(request: Request) -> AnalysisRepository:

--- a/api/test/integration/test_land_ghg_inventory.py
+++ b/api/test/integration/test_land_ghg_inventory.py
@@ -11,6 +11,7 @@ from asgi_lifespan import LifespanManager
 from fastapi import Depends
 from httpx import ASGITransport, AsyncClient
 
+from app.authentication import get_authenticator
 from app.domain.analyzers.land_ghg_inventory_analyzer import (
     INPUT_URIS,
     LandGHGInventoryAnalyzer,
@@ -22,6 +23,7 @@ from app.infrastructure.persistence.file_system_analysis_repository import (
 )
 from app.main import app
 from app.models.common.areas_of_interest import AdminAreaOfInterest
+from app.models.common.authentication import User
 from app.models.land_change.land_ghg_inventory import (
     ANALYTICS_NAME,
     LandGHGInventoryAnalyticsIn,
@@ -60,6 +62,14 @@ AGRICULTURE_PAYLOAD = {
     "category": ["cropland", "livestock"],
     "gross_emissions_MgCO2e": [123.0, 456.0],
 }
+
+
+class FakeAdminAuthenticator:
+    """Authenticates any token as a ResourceWatch admin, so the flow tests focus
+    on behavior rather than a live RW call."""
+
+    async def get_user(self, token):
+        return User(id="admin", role="ADMIN", extraUserData={})
 
 
 def get_file_system_analysis_repository() -> AnalysisRepository:
@@ -101,11 +111,14 @@ class TestLandGHGInventoryPostWithNoPreviousRequest:
         app.dependency_overrides[get_analysis_repository] = (
             get_file_system_analysis_repository
         )
+        app.dependency_overrides[get_authenticator] = FakeAdminAuthenticator
         delete_resource_files(ANALYTICS_NAME, resource_tp)
 
         async with LifespanManager(app):
             async with AsyncClient(
-                transport=ASGITransport(app), base_url="http://testserver"
+                transport=ASGITransport(app),
+                base_url="http://testserver",
+                headers={"Authorization": "Bearer test-admin"},
             ) as client:
                 test_request = await client.post(
                     f"/v0/land_change/{ANALYTICS_NAME}/analytics",
@@ -162,6 +175,28 @@ class TestLandGHGInventoryPostWithNoPreviousRequest:
             {"aoi_id", "aoi_type", "category", "gross_emissions_MgCO2e"}
         )
         assert set(agriculture["category"]) == {"cropland", "livestock"}
+
+
+@pytest.mark.asyncio
+async def test_requests_without_a_token_are_unauthorized():
+    app.dependency_overrides[create_analysis_service] = (
+        create_analysis_service_for_tests
+    )
+    app.dependency_overrides[get_analysis_repository] = (
+        get_file_system_analysis_repository
+    )
+    try:
+        async with LifespanManager(app):
+            async with AsyncClient(
+                transport=ASGITransport(app), base_url="http://testserver"
+            ) as client:
+                response = await client.post(
+                    f"/v0/land_change/{ANALYTICS_NAME}/analytics",
+                    json={"aoi": {"type": "admin", "ids": ["BRA.1"]}},
+                )
+        assert response.status_code == 401
+    finally:
+        app.dependency_overrides.clear()
 
 
 def test_endpoint_is_hidden_from_openapi_schema_but_registered():

--- a/api/test/unit/infrastructure/external_services/test_resource_watch_authenticator.py
+++ b/api/test/unit/infrastructure/external_services/test_resource_watch_authenticator.py
@@ -1,0 +1,52 @@
+import httpx
+import pytest
+
+from app.infrastructure.external_services.resource_watch_authenticator import (
+    ResourceWatchAuthenticator,
+    UpstreamAuthError,
+)
+
+
+def build_authenticator(handler):
+    """Authenticator wired to an in-memory transport standing in for the RW API."""
+    transport = httpx.MockTransport(handler)
+    return ResourceWatchAuthenticator(
+        api_url="https://rw.test",
+        client_factory=lambda: httpx.AsyncClient(transport=transport),
+    )
+
+
+@pytest.mark.asyncio
+async def test_returns_user_for_valid_token():
+    def handler(request):
+        # sends the token as a bearer credential to the check-logged endpoint
+        assert request.headers["Authorization"] == "Bearer good-token"
+        assert request.url.path == "/auth/check-logged"
+        return httpx.Response(
+            200,
+            json={"id": "u1", "role": "ADMIN", "extraUserData": {"apps": ["rw"]}},
+        )
+
+    user = await build_authenticator(handler).get_user("good-token")
+
+    assert user is not None
+    assert user.id == "u1"
+    assert user.role == "ADMIN"
+
+
+@pytest.mark.asyncio
+async def test_returns_none_for_unauthorized_token():
+    def handler(request):
+        return httpx.Response(401, json={"errors": [{"detail": "Unauthorized"}]})
+
+    assert await build_authenticator(handler).get_user("bad-token") is None
+
+
+@pytest.mark.asyncio
+async def test_raises_on_upstream_failure():
+    # anything other than 200/401 means we cannot make an auth decision
+    def handler(request):
+        return httpx.Response(500, text="boom")
+
+    with pytest.raises(UpstreamAuthError):
+        await build_authenticator(handler).get_user("whatever")

--- a/api/test/unit/infrastructure/external_services/test_resource_watch_authenticator.py
+++ b/api/test/unit/infrastructure/external_services/test_resource_watch_authenticator.py
@@ -3,17 +3,47 @@ import pytest
 
 from app.infrastructure.external_services.resource_watch_authenticator import (
     ResourceWatchAuthenticator,
+    TokenValidationCache,
     UpstreamAuthError,
 )
 
 
-def build_authenticator(handler):
+def build_authenticator(handler, cache=None):
     """Authenticator wired to an in-memory transport standing in for the RW API."""
     transport = httpx.MockTransport(handler)
     return ResourceWatchAuthenticator(
         api_url="https://rw.test",
         client_factory=lambda: httpx.AsyncClient(transport=transport),
+        cache=cache,
     )
+
+
+class FakeClock:
+    """Deterministic monotonic clock so TTL tests don't sleep."""
+
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+def counting_handler(response_factory):
+    """A MockTransport handler that counts how many times RW was actually hit."""
+    calls = {"count": 0}
+
+    def handler(request):
+        calls["count"] += 1
+        return response_factory()
+
+    return handler, calls
+
+
+def admin_response():
+    return httpx.Response(200, json={"id": "u1", "role": "ADMIN", "extraUserData": {}})
 
 
 @pytest.mark.asyncio
@@ -50,3 +80,55 @@ async def test_raises_on_upstream_failure():
 
     with pytest.raises(UpstreamAuthError):
         await build_authenticator(handler).get_user("whatever")
+
+
+@pytest.mark.asyncio
+async def test_valid_token_is_cached_within_ttl():
+    cache = TokenValidationCache(ttl_seconds=120, clock=FakeClock())
+    handler, calls = counting_handler(admin_response)
+    authenticator = build_authenticator(handler, cache=cache)
+
+    first = await authenticator.get_user("t")
+    second = await authenticator.get_user("t")
+
+    assert first.role == "ADMIN" and second.role == "ADMIN"
+    assert calls["count"] == 1  # RW hit once, second call served from cache
+
+
+@pytest.mark.asyncio
+async def test_invalid_token_result_is_cached():
+    # negative results are cached too, so an invalid-token flood can't hammer RW
+    cache = TokenValidationCache(ttl_seconds=120, clock=FakeClock())
+    handler, calls = counting_handler(lambda: httpx.Response(401))
+    authenticator = build_authenticator(handler, cache=cache)
+
+    assert await authenticator.get_user("bad") is None
+    assert await authenticator.get_user("bad") is None
+    assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_expires_after_ttl():
+    clock = FakeClock()
+    cache = TokenValidationCache(ttl_seconds=120, clock=clock)
+    handler, calls = counting_handler(admin_response)
+    authenticator = build_authenticator(handler, cache=cache)
+
+    await authenticator.get_user("t")
+    clock.advance(121)
+    await authenticator.get_user("t")
+
+    assert calls["count"] == 2  # re-queried after the entry expired
+
+
+@pytest.mark.asyncio
+async def test_upstream_error_is_not_cached():
+    # a failed decision must not stick; the next call should retry
+    responses = [httpx.Response(500), admin_response()]
+    authenticator = build_authenticator(
+        lambda request: responses.pop(0), cache=TokenValidationCache()
+    )
+
+    with pytest.raises(UpstreamAuthError):
+        await authenticator.get_user("t")
+    assert (await authenticator.get_user("t")).role == "ADMIN"

--- a/api/test/unit/test_authentication.py
+++ b/api/test/unit/test_authentication.py
@@ -1,0 +1,57 @@
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from app.authentication import get_authenticator, require_resource_watch_admin
+from app.models.common.authentication import User
+
+_app = FastAPI()
+
+
+@_app.get("/protected")
+async def protected(user: User = Depends(require_resource_watch_admin)):
+    return {"id": user.id, "role": user.role}
+
+
+class FakeAuthenticator:
+    """Maps a token to a User (or None for an invalid/expired token)."""
+
+    def __init__(self, users):
+        self.users = users
+
+    async def get_user(self, token):
+        return self.users.get(token)
+
+
+def use(users):
+    _app.dependency_overrides[get_authenticator] = lambda: FakeAuthenticator(users)
+
+
+def teardown_function():
+    _app.dependency_overrides.clear()
+
+
+_client = TestClient(_app)
+
+
+def test_missing_token_returns_401():
+    use({})
+    assert _client.get("/protected").status_code == 401
+
+
+def test_invalid_token_returns_401():
+    use({"bad": None})
+    r = _client.get("/protected", headers={"Authorization": "Bearer bad"})
+    assert r.status_code == 401
+
+
+def test_non_admin_token_returns_403():
+    use({"t": User(id="u", role="USER", extraUserData={})})
+    r = _client.get("/protected", headers={"Authorization": "Bearer t"})
+    assert r.status_code == 403
+
+
+def test_admin_token_passes():
+    use({"t": User(id="u", role="ADMIN", extraUserData={})})
+    r = _client.get("/protected", headers={"Authorization": "Bearer t"})
+    assert r.status_code == 200
+    assert r.json()["role"] == "ADMIN"


### PR DESCRIPTION
## Require ResourceWatch admin auth — Land GHG Inventory endpoint

Gates **only** the Land GHG Inventory router (`POST` create + `GET` poll) behind a **ResourceWatch admin** bearer token, validated against RW's `/auth/check-logged` (same as gfw-data-api's `who_am_i`). Every other endpoint stays open. A short-TTL cache (120s) fronts the RW call so the LRO poll loop doesn't re-validate on every request — a deliberate improvement over gfw-data-api, which doesn't cache.

```mermaid
sequenceDiagram
    participant C as Client
    participant G as Admin guard
    participant K as Token cache
    participant RW as ResourceWatch

    C->>G: Request + Bearer token
    Note over G: no token → 401
    G->>K: lookup token
    alt cache miss
        G->>RW: GET /auth/check-logged
        RW-->>G: 200 user / 401 / error
        Note over G: error → 502
        G->>K: cache user or None
    else cache hit
        K-->>G: user or None
    end
    Note over G: None → 401 · role≠ADMIN → 403
    G-->>C: admin → 202 / 200