### PR TITLE
PZB-1207: add lgms soils pipeline and API

### DIFF
--- a/api/app/domain/analyzers/land_ghg_inventory_analyzer.py
+++ b/api/app/domain/analyzers/land_ghg_inventory_analyzer.py
@@ -16,6 +16,14 @@ VEGETATION_MEASURES = (
     "area_ha",
 )
 
+# mineral soil measures returned per aoi_id (single static snapshot, no year axis)
+MINERAL_SOIL_MEASURES = (
+    "gross_emissions_MgCO2e",
+    "gross_removals_MgCO2",
+    "net_flux_MgCO2e",
+    "area_ha",
+)
+
 INPUT_URIS = {
     Environment.staging: {},
     Environment.production: {
@@ -26,6 +34,14 @@ INPUT_URIS = {
         "admin_agriculture_results_uri": (
             "s3://lcl-analytics/zonal-statistics/land_ghg_inventory-agriculture/"
             "v20260727/admin-land_ghg_inventory-agriculture.parquet"
+        ),
+        "admin_mineral_soil_results_uri": (
+            "s3://lcl-analytics/zonal-statistics/land_ghg_inventory-mineral_soil/"
+            "v20260729/admin-land_ghg_inventory-mineral_soil.parquet"
+        ),
+        "admin_organic_soil_results_uri": (
+            "s3://lcl-analytics/zonal-statistics/land_ghg_inventory-organic_soil/"
+            "v20260729/admin-land_ghg_inventory-organic_soil.parquet"
         ),
     },
 }
@@ -41,7 +57,13 @@ class LandGHGInventoryAnalyzer(Analyzer):
         land_state_class x year.
       - "agriculture": a coarse snapshot of gross emissions by category
         (cropland) only - no year, removals, net flux, or area.
-    "soil" is added as a further key later."""
+      - "mineral_soil": gross emissions / removals / net flux / area by
+        aoi_id only - a single static snapshot (the 2015-2020 SOC change
+        interval), no year axis.
+      - "organic_soil": gross emissions / area by aoi_id x interval_end_year
+        (2020 or 2024 - the zarr's native 5-year block labels, covering the
+        2016-2020 and 2021-2024 vegetation periods respectively), not
+        broadcast to annual years."""
 
     def __init__(
         self,
@@ -58,11 +80,18 @@ class LandGHGInventoryAnalyzer(Analyzer):
 
         analytics_in = LandGHGInventoryAnalyticsIn(**analysis.metadata)
         aoi_ids = analytics_in.aoi.ids
-        vegetation, agriculture = await asyncio.gather(
+        vegetation, agriculture, mineral_soil, organic_soil = await asyncio.gather(
             self.analyze_vegetation(aoi_ids),
             self.analyze_agriculture(aoi_ids),
+            self.analyze_mineral_soil(aoi_ids),
+            self.analyze_organic_soil(aoi_ids),
         )
-        analysis.result = {"vegetation": vegetation, "agriculture": agriculture}
+        analysis.result = {
+            "vegetation": vegetation,
+            "agriculture": agriculture,
+            "mineral_soil": mineral_soil,
+            "organic_soil": organic_soil,
+        }
 
     async def analyze_vegetation(self, aoi_ids) -> Dict[str, Any]:
         columns = ("aoi_id", "land_state_class", "year") + VEGETATION_MEASURES
@@ -74,6 +103,20 @@ class LandGHGInventoryAnalyzer(Analyzer):
     async def analyze_agriculture(self, aoi_ids) -> Dict[str, Any]:
         columns = ("aoi_id", "aoi_type", "category", "gross_emissions_MgCO2e")
         return await self._select(self.query_services["agriculture"], columns, aoi_ids)
+
+    async def analyze_mineral_soil(self, aoi_ids) -> Dict[str, Any]:
+        columns = ("aoi_id", "aoi_type") + MINERAL_SOIL_MEASURES
+        return await self._select(self.query_services["mineral_soil"], columns, aoi_ids)
+
+    async def analyze_organic_soil(self, aoi_ids) -> Dict[str, Any]:
+        columns = (
+            "aoi_id",
+            "aoi_type",
+            "interval_end_year",
+            "gross_emissions_MgCO2e",
+            "area_ha",
+        )
+        return await self._select(self.query_services["organic_soil"], columns, aoi_ids)
 
     @staticmethod
     async def _select(query_service, columns, aoi_ids) -> Dict[str, Any]:

--- a/api/app/models/land_change/land_ghg_inventory.py
+++ b/api/app/models/land_change/land_ghg_inventory.py
@@ -11,7 +11,7 @@ ANALYTICS_NAME = "land_ghg_inventory"
 
 class LandGHGInventoryAnalyticsIn(AnalyticsIn):
     _analytics_name: str = PrivateAttr(default=ANALYTICS_NAME)
-    _version: str = PrivateAttr(default="v20260723")
+    _version: str = PrivateAttr(default="v20260730")
     aoi: AdminAreaOfInterest = Field(
         ...,
         title="AOI",
@@ -57,6 +57,25 @@ class LandGHGInventoryAnalyticsResponse(Response):
                                 "aoi_type": ["admin"],
                                 "category": ["cropland"],
                                 "gross_emissions_MgCO2e": [123234500000.0],
+                            },
+                            # single static snapshot (2015-2020 SOC change
+                            # interval): no year axis
+                            "mineral_soil": {
+                                "aoi_id": ["BRA.1"],
+                                "aoi_type": ["admin"],
+                                "gross_emissions_MgCO2e": [4533948.0],
+                                "gross_removals_MgCO2": [-2740651.0],
+                                "net_flux_MgCO2e": [1793298.0],
+                                "area_ha": [8509086.0],
+                            },
+                            # native 5-year block labels (2020, 2024), not
+                            # broadcast to annual vegetation years
+                            "organic_soil": {
+                                "aoi_id": ["BRA.1", "BRA.1"],
+                                "aoi_type": ["admin", "admin"],
+                                "interval_end_year": [2020, 2024],
+                                "gross_emissions_MgCO2e": [11.6, 313515.6],
+                                "area_ha": [8509086.0, 8509086.0],
                             },
                         },
                         "metadata": {

--- a/api/app/routers/land_change/land_ghg_inventory/land_ghg_inventory.py
+++ b/api/app/routers/land_change/land_ghg_inventory/land_ghg_inventory.py
@@ -51,6 +51,12 @@ def create_analysis_service(
                 "agriculture": DuckDbPrecalcQueryService(
                     table_uri=input_uris["admin_agriculture_results_uri"]
                 ),
+                "mineral_soil": DuckDbPrecalcQueryService(
+                    table_uri=input_uris["admin_mineral_soil_results_uri"]
+                ),
+                "organic_soil": DuckDbPrecalcQueryService(
+                    table_uri=input_uris["admin_organic_soil_results_uri"]
+                ),
             },
             input_uris=input_uris,
         ),

--- a/api/test/integration/test_land_ghg_inventory.py
+++ b/api/test/integration/test_land_ghg_inventory.py
@@ -61,6 +61,23 @@ AGRICULTURE_PAYLOAD = {
     "gross_emissions_MgCO2e": [123.0],
 }
 
+MINERAL_SOIL_PAYLOAD = {
+    "aoi_id": ["BRA.1"],
+    "aoi_type": ["admin"],
+    "gross_emissions_MgCO2e": [100.0],
+    "gross_removals_MgCO2": [-10.0],
+    "net_flux_MgCO2e": [90.0],
+    "area_ha": [1.0],
+}
+
+ORGANIC_SOIL_PAYLOAD = {
+    "aoi_id": ["BRA.1", "BRA.1"],
+    "aoi_type": ["admin", "admin"],
+    "interval_end_year": [2020, 2024],
+    "gross_emissions_MgCO2e": [10.0, 20.0],
+    "area_ha": [1.0, 1.0],
+}
+
 
 def get_file_system_analysis_repository() -> AnalysisRepository:
     return FileSystemAnalysisRepository(ANALYTICS_NAME)
@@ -77,6 +94,8 @@ def create_analysis_service_for_tests(
             query_services={
                 "vegetation": FakeQueryService(VEGETATION_PAYLOAD),
                 "agriculture": FakeQueryService(AGRICULTURE_PAYLOAD),
+                "mineral_soil": FakeQueryService(MINERAL_SOIL_PAYLOAD),
+                "organic_soil": FakeQueryService(ORGANIC_SOIL_PAYLOAD),
             },
             input_uris=INPUT_URIS[Environment.production],
         ),
@@ -140,7 +159,12 @@ class TestLandGHGInventoryPostWithNoPreviousRequest:
 
         assert data["status"] == "saved"
         # one table per category
-        assert set(data["result"]) == {"vegetation", "agriculture"}
+        assert set(data["result"]) == {
+            "vegetation",
+            "agriculture",
+            "mineral_soil",
+            "organic_soil",
+        }
 
         vegetation = data["result"]["vegetation"]
         assert set(vegetation).issuperset(
@@ -162,6 +186,32 @@ class TestLandGHGInventoryPostWithNoPreviousRequest:
             {"aoi_id", "aoi_type", "category", "gross_emissions_MgCO2e"}
         )
         assert set(agriculture["category"]) == {"cropland"}
+
+        mineral_soil = data["result"]["mineral_soil"]
+        assert set(mineral_soil).issuperset(
+            {
+                "aoi_id",
+                "aoi_type",
+                "gross_emissions_MgCO2e",
+                "gross_removals_MgCO2",
+                "net_flux_MgCO2e",
+                "area_ha",
+            }
+        )
+        assert "year" not in mineral_soil
+        assert "interval_end_year" not in mineral_soil
+
+        organic_soil = data["result"]["organic_soil"]
+        assert set(organic_soil).issuperset(
+            {
+                "aoi_id",
+                "aoi_type",
+                "interval_end_year",
+                "gross_emissions_MgCO2e",
+                "area_ha",
+            }
+        )
+        assert set(organic_soil["interval_end_year"]) == {2020, 2024}
 
 
 def test_endpoint_is_hidden_from_openapi_schema_but_registered():

--- a/api/test/unit/domain/analyzers/test_land_ghg_inventory_analyzer.py
+++ b/api/test/unit/domain/analyzers/test_land_ghg_inventory_analyzer.py
@@ -37,6 +37,26 @@ EXPECTED_AGRICULTURE_COLUMNS = {
     "gross_emissions_MgCO2e",
 }
 
+# mineral_soil is a single static snapshot: no year/category axis
+EXPECTED_MINERAL_SOIL_COLUMNS = {
+    "aoi_id",
+    "aoi_type",
+    "gross_emissions_MgCO2e",
+    "gross_removals_MgCO2",
+    "net_flux_MgCO2e",
+    "area_ha",
+}
+
+# organic_soil is grouped by interval_end_year (native 2020/2024 block labels),
+# emissions + area only - no removals/net flux/land_state_class
+EXPECTED_ORGANIC_SOIL_COLUMNS = {
+    "aoi_id",
+    "aoi_type",
+    "interval_end_year",
+    "gross_emissions_MgCO2e",
+    "area_ha",
+}
+
 
 @pytest.fixture
 def vegetation_parquet(tmp_path):
@@ -73,38 +93,94 @@ def agriculture_parquet(tmp_path):
     return parquet_file
 
 
-def build_analyzer(vegetation_parquet, agriculture_parquet):
+@pytest.fixture
+def mineral_soil_parquet(tmp_path):
+    """Mineral soil static snapshot parquet: one row per aoi_id, no year axis."""
+    df = pd.DataFrame(
+        {
+            "aoi_id": ["BRA.1", "COL", "PER"],
+            "aoi_type": ["admin", "admin", "admin"],
+            "gross_emissions_MgCO2e": [100.0, 50.0, 5.0],
+            "gross_removals_MgCO2": [-10.0, -5.0, -1.0],
+            "net_flux_MgCO2e": [90.0, 45.0, 4.0],
+            "area_ha": [1.0, 3.0, 4.0],
+        }
+    )
+    parquet_file = tmp_path / "mineral_soil.parquet"
+    df.to_parquet(parquet_file, index=False)
+    return parquet_file
+
+
+@pytest.fixture
+def organic_soil_parquet(tmp_path):
+    """Organic soil parquet: one row per aoi_id x interval_end_year (2020, 2024)."""
+    df = pd.DataFrame(
+        {
+            "aoi_id": ["BRA.1", "BRA.1", "COL", "COL", "PER", "PER"],
+            "aoi_type": ["admin"] * 6,
+            "interval_end_year": [2020, 2024, 2020, 2024, 2020, 2024],
+            "gross_emissions_MgCO2e": [10.0, 20.0, 5.0, 6.0, 1.0, 2.0],
+            "area_ha": [1.0, 1.0, 3.0, 3.0, 4.0, 4.0],
+        }
+    )
+    parquet_file = tmp_path / "organic_soil.parquet"
+    df.to_parquet(parquet_file, index=False)
+    return parquet_file
+
+
+def build_analyzer(
+    vegetation_parquet, agriculture_parquet, mineral_soil_parquet, organic_soil_parquet
+):
     return LandGHGInventoryAnalyzer(
         query_services={
             "vegetation": DuckDbPrecalcQueryService(table_uri=vegetation_parquet),
             "agriculture": DuckDbPrecalcQueryService(table_uri=agriculture_parquet),
+            "mineral_soil": DuckDbPrecalcQueryService(table_uri=mineral_soil_parquet),
+            "organic_soil": DuckDbPrecalcQueryService(table_uri=organic_soil_parquet),
         },
         input_uris=INPUT_URIS[Environment.production],
     )
 
 
 @pytest.mark.asyncio
-async def test_result_has_a_table_per_category(vegetation_parquet, agriculture_parquet):
-    analytics_in = LandGHGInventoryAnalyticsIn(
-        aoi=AdminAreaOfInterest(ids=["BRA.1", "COL"])
-    ).model_dump()
-    analysis = Analysis(None, analytics_in, AnalysisStatus.saved)
-
-    await build_analyzer(vegetation_parquet, agriculture_parquet).analyze(analysis)
-
-    assert set(analysis.result) == {"vegetation", "agriculture"}
-
-
-@pytest.mark.asyncio
-async def test_vegetation_query_returns_flux_by_land_state_and_year(
-    vegetation_parquet, agriculture_parquet
+async def test_result_has_a_table_per_category(
+    vegetation_parquet, agriculture_parquet, mineral_soil_parquet, organic_soil_parquet
 ):
     analytics_in = LandGHGInventoryAnalyticsIn(
         aoi=AdminAreaOfInterest(ids=["BRA.1", "COL"])
     ).model_dump()
     analysis = Analysis(None, analytics_in, AnalysisStatus.saved)
 
-    await build_analyzer(vegetation_parquet, agriculture_parquet).analyze(analysis)
+    await build_analyzer(
+        vegetation_parquet,
+        agriculture_parquet,
+        mineral_soil_parquet,
+        organic_soil_parquet,
+    ).analyze(analysis)
+
+    assert set(analysis.result) == {
+        "vegetation",
+        "agriculture",
+        "mineral_soil",
+        "organic_soil",
+    }
+
+
+@pytest.mark.asyncio
+async def test_vegetation_query_returns_flux_by_land_state_and_year(
+    vegetation_parquet, agriculture_parquet, mineral_soil_parquet, organic_soil_parquet
+):
+    analytics_in = LandGHGInventoryAnalyticsIn(
+        aoi=AdminAreaOfInterest(ids=["BRA.1", "COL"])
+    ).model_dump()
+    analysis = Analysis(None, analytics_in, AnalysisStatus.saved)
+
+    await build_analyzer(
+        vegetation_parquet,
+        agriculture_parquet,
+        mineral_soil_parquet,
+        organic_soil_parquet,
+    ).analyze(analysis)
 
     result = pd.DataFrame(analysis.result["vegetation"])
     assert EXPECTED_VEGETATION_COLUMNS.issubset(result.columns)
@@ -121,14 +197,19 @@ async def test_vegetation_query_returns_flux_by_land_state_and_year(
 
 @pytest.mark.asyncio
 async def test_agriculture_query_returns_emissions_by_category(
-    vegetation_parquet, agriculture_parquet
+    vegetation_parquet, agriculture_parquet, mineral_soil_parquet, organic_soil_parquet
 ):
     analytics_in = LandGHGInventoryAnalyticsIn(
         aoi=AdminAreaOfInterest(ids=["BRA.1", "COL"])
     ).model_dump()
     analysis = Analysis(None, analytics_in, AnalysisStatus.saved)
 
-    await build_analyzer(vegetation_parquet, agriculture_parquet).analyze(analysis)
+    await build_analyzer(
+        vegetation_parquet,
+        agriculture_parquet,
+        mineral_soil_parquet,
+        organic_soil_parquet,
+    ).analyze(analysis)
 
     result = pd.DataFrame(analysis.result["agriculture"])
     assert set(result.columns) == EXPECTED_AGRICULTURE_COLUMNS
@@ -136,6 +217,63 @@ async def test_agriculture_query_returns_emissions_by_category(
     assert set(result.aoi_id) == {"BRA.1", "COL"}
     assert set(result.category) == {"cropland"}
     assert set(result.aoi_type) == {"admin"}
+
+
+@pytest.mark.asyncio
+async def test_mineral_soil_query_returns_flux_by_aoi(
+    vegetation_parquet, agriculture_parquet, mineral_soil_parquet, organic_soil_parquet
+):
+    analytics_in = LandGHGInventoryAnalyticsIn(
+        aoi=AdminAreaOfInterest(ids=["BRA.1", "COL"])
+    ).model_dump()
+    analysis = Analysis(None, analytics_in, AnalysisStatus.saved)
+
+    await build_analyzer(
+        vegetation_parquet,
+        agriculture_parquet,
+        mineral_soil_parquet,
+        organic_soil_parquet,
+    ).analyze(analysis)
+
+    result = pd.DataFrame(analysis.result["mineral_soil"])
+    assert set(result.columns) == EXPECTED_MINERAL_SOIL_COLUMNS
+    assert "year" not in result.columns
+    assert "interval_end_year" not in result.columns
+    # only the requested admin ids come back (PER filtered out)
+    assert set(result.aoi_id) == {"BRA.1", "COL"}
+    assert set(result.aoi_type) == {"admin"}
+    bra = result[result.aoi_id == "BRA.1"].iloc[0]
+    assert bra.gross_emissions_MgCO2e == 100.0
+    assert bra.net_flux_MgCO2e == 90.0
+
+
+@pytest.mark.asyncio
+async def test_organic_soil_query_returns_emissions_by_interval_end_year(
+    vegetation_parquet, agriculture_parquet, mineral_soil_parquet, organic_soil_parquet
+):
+    analytics_in = LandGHGInventoryAnalyticsIn(
+        aoi=AdminAreaOfInterest(ids=["BRA.1", "COL"])
+    ).model_dump()
+    analysis = Analysis(None, analytics_in, AnalysisStatus.saved)
+
+    await build_analyzer(
+        vegetation_parquet,
+        agriculture_parquet,
+        mineral_soil_parquet,
+        organic_soil_parquet,
+    ).analyze(analysis)
+
+    result = pd.DataFrame(analysis.result["organic_soil"])
+    assert set(result.columns) == EXPECTED_ORGANIC_SOIL_COLUMNS
+    # only the requested admin ids come back (PER filtered out)
+    assert set(result.aoi_id) == {"BRA.1", "COL"}
+    assert set(result.aoi_type) == {"admin"}
+    # native block labels, not expanded to vegetation calendar years
+    assert set(result.interval_end_year) == {2020, 2024}
+    bra_2024 = result[
+        (result.aoi_id == "BRA.1") & (result.interval_end_year == 2024)
+    ].iloc[0]
+    assert bra_2024.gross_emissions_MgCO2e == 20.0
 
 
 def test_rejects_non_admin_aoi():

--- a/pipelines/globals.py
+++ b/pipelines/globals.py
@@ -28,11 +28,20 @@ land_ghg_inventory_vegetation_zarr_uri = (
     "version_1_0_5__standard__global/mega_zarr/annual_intervals/4000_pixels/"
     "20260130/vegetation_zarr.zarr"
 )
-# Mineral soil organic carbon (SOC v1.0.1). 5-year interval axis (index 0..4);
-# per-hectare stock-change rates. (Organic peat soil is a follow-up.)
+# Mineral soil organic carbon (SOC v1.0.1). 5-year change-interval index axis
+# (index 0..4, not calendar years); per-hectare stock-change rates. Only index 3
+# (the 2015-2020 change interval) is used -- index 4 (2020-2022) is distrusted
+# per the AFOLU_GHG_flux_model team (anomalously high gross loss/gain).
 land_ghg_inventory_soc_zarr_uri = (
     "s3://gfw2-data/climate/AFOLU_flux_model/LULUCF/outputs_soil_organic_carbon/"
     "version_1_0_1__standard__global/zarr/4000_pixels/20260611/SOC_zarr.zarr"
+)
+# Organic (peat) soil emissions (v1.0.1). 5-year block axis with real calendar-year
+# labels [2005, 2010, 2015, 2020, 2024]; per-hectare rates. Only the last two blocks
+# (2020, 2024) are used, covering the 2016-2020 and 2021-2024 vegetation periods.
+land_ghg_inventory_organic_soil_zarr_uri = (
+    "s3://gfw2-data/climate/AFOLU_flux_model/organic_soils/outputs/version_1_0_1/"
+    "mega_zarr/ogh_mixed_f1_f15_f2_20260513/five_year/4000_pixels/20260525/mega.zarr"
 )
 # Agriculture emissions (cropland + livestock). Single static snapshot, no year
 # axis; per-pixel absolute totals (not per-hectare). group="pipeline".

--- a/pipelines/land_ghg_inventory/mineral_soil_stages.py
+++ b/pipelines/land_ghg_inventory/mineral_soil_stages.py
@@ -1,0 +1,141 @@
+"""Zonal-statistics stages for Land GHG inventory mineral soil organic carbon (SOC).
+
+Sums per-hectare SOC stock-change fluxes (converted to per-pixel totals by
+multiplying by pixel area) grouped by admin unit only, then rolls up to aoi_id.
+The reduce and GADM roll-up are reused from ``pipelines.prefect_flows.common_stages``.
+
+Only the 2015-2020 change interval (zarr ``year`` index 3) is used -- see
+``pipelines.globals.land_ghg_inventory_soc_zarr_uri`` -- so there is no year axis;
+this is a single static snapshot, applied uniformly across all vegetation years.
+
+Output parquet schema (one row per aoi_id)::
+
+    aoi_id                     str    admin unit, e.g. "BRA", "BRA.1", "BRA.1.1"
+    aoi_type                   str    always "admin"
+    gross_emissions_MgCO2e     float  summed gross emissions (SOC loss)
+    gross_removals_MgCO2       float  summed gross removals (SOC gain)
+    net_flux_MgCO2e            float  summed net flux (emissions - removals)
+    area_ha                    float  summed area, hectares
+"""
+
+from typing import Dict, Optional, Tuple
+
+import pandas as pd
+import xarray as xr
+from shapely.geometry import Polygon
+
+from pipelines.land_ghg_inventory.common import align_to, clip
+from pipelines.prefect_flows.common_stages import (
+    _load_zarr,
+)
+from pipelines.prefect_flows.common_stages import (
+    create_result_dataframe as common_create_result_dataframe,
+)
+from pipelines.prefect_flows.common_stages import (
+    rollup_by_gadm_and_convert_to_aoi,
+)
+
+MEASURES = ["gross_emissions_MgCO2e", "gross_removals_MgCO2", "net_flux_MgCO2e"]
+AREA_LAYER = "area_ha"
+CHANGE_INTERVAL_INDEX = 3  # the 2015-2020 change interval; index 4 is distrusted
+
+# canonical measure -> per-hectare source variable in the SOC zarr
+SOC_SOURCE_VARS = {
+    "gross_emissions_MgCO2e": "SOC_loss__mineral_soil_extent__0-30cm_MgCO2_ha_yr",
+    "gross_removals_MgCO2": "SOC_gain__mineral_soil_extent__0-30cm_MgCO2_ha_yr",
+    "net_flux_MgCO2e": "SOC_net__mineral_soil_extent__0-30cm_MgCO2_ha_yr",
+}
+
+
+def setup_compute(
+    measures: Dict[str, xr.DataArray],
+    pixel_area: xr.DataArray,
+    country: xr.DataArray,
+    region: xr.DataArray,
+    subregion: xr.DataArray,
+    expected_groups: Tuple,
+) -> Tuple:
+    """Build the per-pixel flux cube + group-by layers for the reduce.
+
+    The zarr fluxes are stored per-hectare, so ``measures`` (canonical name ->
+    per-hectare DataArray) are each multiplied by ``pixel_area`` (hectares) to get
+    per-pixel totals and stacked with an ``area_ha`` layer along ``analysis_layer``.
+    Grouping is admin-only (no year, no categorical axis).
+    """
+    pixel_area = pixel_area.fillna(0)
+    layers = [
+        (measures[name].fillna(0) * pixel_area).astype("float64").rename(name)
+        for name in measures
+    ]
+    layers.append(
+        (pixel_area * xr.ones_like(measures[MEASURES[0]]))
+        .astype("float64")
+        .rename(AREA_LAYER)
+    )
+    cube = xr.concat(layers, dim="analysis_layer").assign_coords(
+        analysis_layer=list(measures) + [AREA_LAYER]
+    )
+    groupbys = (
+        country.rename("country"),
+        region.rename("region"),
+        subregion.rename("subregion"),
+    )
+    return (cube, groupbys, expected_groups)
+
+
+def create_result_dataframe(reduced: xr.DataArray) -> pd.DataFrame:
+    """Reshape the sparse reduce into tidy aoi_id rows (no year/category axis)."""
+    df = common_create_result_dataframe(reduced)
+    df = df.pivot_table(
+        index=["country", "region", "subregion"],
+        columns="analysis_layer",
+        values="value",
+        aggfunc="sum",
+    ).reset_index()
+    df.columns.name = None
+
+    result = rollup_by_gadm_and_convert_to_aoi(df, [])
+    # a structurally-zero measure is absent from the sparse reduce and pivots to
+    # NaN; emit dense 0.0 so consumers aren't surprised.
+    value_columns = MEASURES + [AREA_LAYER]
+    result[value_columns] = result.reindex(columns=value_columns).fillna(0.0)
+    return result
+
+
+def load_data(
+    soc_uri: str,
+    pixel_area_uri: str,
+    country_uri: str,
+    region_uri: str,
+    subregion_uri: str,
+    bbox: Optional[Polygon] = None,
+) -> Tuple[xr.Dataset, xr.DataArray, xr.DataArray, xr.DataArray, xr.DataArray]:
+    """Load the SOC fluxes at the 2015-2020 change interval, pixel area, and GADM
+    layers, aligned to the SOC grid (native 30m, so alignment is 1:1)."""
+    soc = _load_zarr(soc_uri)[list(SOC_SOURCE_VARS.values())]
+    soc = soc.isel(year=CHANGE_INTERVAL_INDEX, drop=True)
+    soc = clip(soc, bbox)
+    soc = soc.rename({source: name for name, source in SOC_SOURCE_VARS.items()})
+    return (
+        soc,
+        align_to(soc, pixel_area_uri),
+        align_to(soc, country_uri),
+        align_to(soc, region_uri),
+        align_to(soc, subregion_uri),
+    )
+
+
+def setup_mineral_soil_compute(datasets: Tuple, expected_groups: Tuple) -> Tuple:
+    soc, pixel_area, country, region, subregion = datasets
+    return setup_compute(
+        {name: soc[name] for name in MEASURES},
+        pixel_area,
+        country,
+        region,
+        subregion,
+        expected_groups,
+    )
+
+
+def mineral_soil_result_dataframe(reduced: xr.DataArray) -> pd.DataFrame:
+    return create_result_dataframe(reduced)

--- a/pipelines/land_ghg_inventory/mineral_soil_stages.py
+++ b/pipelines/land_ghg_inventory/mineral_soil_stages.py
@@ -67,11 +67,7 @@ def setup_compute(
         (measures[name].fillna(0) * pixel_area).astype("float64").rename(name)
         for name in measures
     ]
-    layers.append(
-        (pixel_area * xr.ones_like(measures[MEASURES[0]]))
-        .astype("float64")
-        .rename(AREA_LAYER)
-    )
+    layers.append(pixel_area.astype("float64").rename(AREA_LAYER))
     cube = xr.concat(layers, dim="analysis_layer").assign_coords(
         analysis_layer=list(measures) + [AREA_LAYER]
     )

--- a/pipelines/land_ghg_inventory/organic_soil_stages.py
+++ b/pipelines/land_ghg_inventory/organic_soil_stages.py
@@ -1,0 +1,140 @@
+"""Zonal-statistics stages for Land GHG inventory organic (peat) soil emissions.
+
+Sums per-hectare burned + drained fluxes (converted to per-pixel totals by
+multiplying by pixel area) grouped by admin unit x interval_end_year, then rolls
+up to aoi_id. The reduce and GADM roll-up are reused from
+``pipelines.prefect_flows.common_stages``.
+
+Only the last two 5-year blocks (zarr ``year`` values 2020 and 2024) are used --
+see ``pipelines.globals.land_ghg_inventory_organic_soil_zarr_uri``. These are
+persisted at their native block resolution, not broadcast to vegetation's 9
+annual years: ``interval_end_year=2020`` covers the 2016-2020 vegetation period,
+``interval_end_year=2024`` covers the 2021-2024 vegetation period. A consumer
+needing annual figures broadcasts each block's value across its corresponding
+vegetation year range themselves.
+
+Output parquet schema (one row per aoi_id x interval_end_year)::
+
+    aoi_id                     str    admin unit, e.g. "BRA", "BRA.1", "BRA.1.1"
+    aoi_type                   str    always "admin"
+    interval_end_year          int    2020 (covers 2016-2020) | 2024 (covers 2021-2024)
+    gross_emissions_MgCO2e     float  summed burned + drained emissions
+    area_ha                    float  summed area, hectares
+"""
+
+from typing import Dict, Optional, Tuple
+
+import pandas as pd
+import xarray as xr
+from shapely.geometry import Polygon
+
+from pipelines.land_ghg_inventory.common import align_to, clip
+from pipelines.prefect_flows.common_stages import (
+    _load_zarr,
+)
+from pipelines.prefect_flows.common_stages import (
+    create_result_dataframe as common_create_result_dataframe,
+)
+from pipelines.prefect_flows.common_stages import (
+    rollup_by_gadm_and_convert_to_aoi,
+)
+
+MEASURES = ["gross_emissions_MgCO2e"]
+AREA_LAYER = "area_ha"
+BLOCK_YEAR_INDICES = [3, 4]  # zarr year values 2020 (2016-2020), 2024 (2021-2024)
+
+# per-hectare source variables summed together into the single emissions measure
+ORGANIC_SOIL_SOURCE_VARS = ["burned_total_Mg_CO2e_ha_yr", "drained_total_Mg_CO2e_ha_yr"]
+
+
+def setup_compute(
+    emissions: xr.DataArray,
+    pixel_area: xr.DataArray,
+    country: xr.DataArray,
+    region: xr.DataArray,
+    subregion: xr.DataArray,
+    interval_end_year: xr.DataArray,
+    expected_groups: Tuple,
+) -> Tuple:
+    """Build the per-pixel emissions cube + group-by layers for the reduce.
+
+    ``emissions`` (burned + drained, per-hectare) is multiplied by ``pixel_area``
+    (hectares) to get per-pixel totals and stacked with an ``area_ha`` layer along
+    ``analysis_layer``. Grouping is admin x interval_end_year (the zarr's native
+    2020/2024 block labels, not vegetation calendar years).
+    """
+    pixel_area = pixel_area.fillna(0)
+    layers = [
+        (emissions.fillna(0) * pixel_area).astype("float64").rename(MEASURES[0]),
+        (pixel_area * xr.ones_like(emissions)).astype("float64").rename(AREA_LAYER),
+    ]
+    cube = xr.concat(layers, dim="analysis_layer").assign_coords(
+        analysis_layer=MEASURES + [AREA_LAYER]
+    )
+    groupbys = (
+        country.rename("country"),
+        region.rename("region"),
+        subregion.rename("subregion"),
+        interval_end_year.rename("interval_end_year"),
+    )
+    return (cube, groupbys, expected_groups)
+
+
+def create_result_dataframe(reduced: xr.DataArray) -> pd.DataFrame:
+    """Reshape the sparse reduce into tidy aoi_id x interval_end_year rows."""
+    df = common_create_result_dataframe(reduced)
+    df = df.pivot_table(
+        index=["country", "region", "subregion", "interval_end_year"],
+        columns="analysis_layer",
+        values="value",
+        aggfunc="sum",
+    ).reset_index()
+    df.columns.name = None
+    df["interval_end_year"] = df["interval_end_year"].astype(int)
+
+    result = rollup_by_gadm_and_convert_to_aoi(df, ["interval_end_year"])
+    # a structurally-zero measure is absent from the sparse reduce and pivots to
+    # NaN; emit dense 0.0 so consumers aren't surprised.
+    value_columns = MEASURES + [AREA_LAYER]
+    result[value_columns] = result.reindex(columns=value_columns).fillna(0.0)
+    return result
+
+
+def load_data(
+    organic_soil_uri: str,
+    pixel_area_uri: str,
+    country_uri: str,
+    region_uri: str,
+    subregion_uri: str,
+    bbox: Optional[Polygon] = None,
+) -> Tuple[xr.Dataset, xr.DataArray, xr.DataArray, xr.DataArray, xr.DataArray]:
+    """Load the organic soil fluxes at the 2020/2024 blocks, pixel area, and GADM
+    layers, aligned to the organic soil grid (native 30m, so alignment is 1:1)."""
+    org = _load_zarr(organic_soil_uri)[ORGANIC_SOIL_SOURCE_VARS]
+    org = org.isel(year=BLOCK_YEAR_INDICES)
+    org = clip(org, bbox)
+    return (
+        org,
+        align_to(org, pixel_area_uri),
+        align_to(org, country_uri),
+        align_to(org, region_uri),
+        align_to(org, subregion_uri),
+    )
+
+
+def setup_organic_soil_compute(datasets: Tuple, expected_groups: Tuple) -> Tuple:
+    org, pixel_area, country, region, subregion = datasets
+    emissions = sum(org[var] for var in ORGANIC_SOIL_SOURCE_VARS)
+    return setup_compute(
+        emissions,
+        pixel_area,
+        country,
+        region,
+        subregion,
+        org["year"].rename("interval_end_year"),
+        expected_groups,
+    )
+
+
+def organic_soil_result_dataframe(reduced: xr.DataArray) -> pd.DataFrame:
+    return create_result_dataframe(reduced)

--- a/pipelines/land_ghg_inventory/organic_soil_stages.py
+++ b/pipelines/land_ghg_inventory/organic_soil_stages.py
@@ -5,6 +5,11 @@ multiplying by pixel area) grouped by admin unit x interval_end_year, then rolls
 up to aoi_id. The reduce and GADM roll-up are reused from
 ``pipelines.prefect_flows.common_stages``.
 
+``area_ha`` is restricted to organic-soil-extent pixels (the zarr's
+``organic_soil`` mask), not every pixel in the admin unit -- burned/drained are
+already zero outside that extent, so this only affects the area total, not the
+emissions total.
+
 Only the last two 5-year blocks (zarr ``year`` values 2020 and 2024) are used --
 see ``pipelines.globals.land_ghg_inventory_organic_soil_zarr_uri``. These are
 persisted at their native block resolution, not broadcast to vegetation's 9
@@ -22,7 +27,7 @@ Output parquet schema (one row per aoi_id x interval_end_year)::
     area_ha                    float  summed area, hectares
 """
 
-from typing import Dict, Optional, Tuple
+from typing import Optional, Tuple
 
 import pandas as pd
 import xarray as xr
@@ -45,10 +50,12 @@ BLOCK_YEAR_INDICES = [3, 4]  # zarr year values 2020 (2016-2020), 2024 (2021-202
 
 # per-hectare source variables summed together into the single emissions measure
 ORGANIC_SOIL_SOURCE_VARS = ["burned_total_Mg_CO2e_ha_yr", "drained_total_Mg_CO2e_ha_yr"]
+ORGANIC_SOIL_MASK_VAR = "organic_soil"
 
 
 def setup_compute(
     emissions: xr.DataArray,
+    organic_soil_mask: xr.DataArray,
     pixel_area: xr.DataArray,
     country: xr.DataArray,
     region: xr.DataArray,
@@ -60,13 +67,14 @@ def setup_compute(
 
     ``emissions`` (burned + drained, per-hectare) is multiplied by ``pixel_area``
     (hectares) to get per-pixel totals and stacked with an ``area_ha`` layer along
-    ``analysis_layer``. Grouping is admin x interval_end_year (the zarr's native
-    2020/2024 block labels, not vegetation calendar years).
+    ``analysis_layer``. The ``area_ha`` layer is restricted to organic-soil-extent
+    pixels via ``organic_soil_mask``. Grouping is admin x interval_end_year (the
+    zarr's native 2020/2024 block labels, not vegetation calendar years).
     """
     pixel_area = pixel_area.fillna(0)
     layers = [
         (emissions.fillna(0) * pixel_area).astype("float64").rename(MEASURES[0]),
-        pixel_area.astype("float64").rename(AREA_LAYER),
+        (pixel_area * organic_soil_mask.fillna(0)).astype("float64").rename(AREA_LAYER),
     ]
     cube = xr.concat(layers, dim="analysis_layer").assign_coords(
         analysis_layer=MEASURES + [AREA_LAYER]
@@ -108,9 +116,12 @@ def load_data(
     subregion_uri: str,
     bbox: Optional[Polygon] = None,
 ) -> Tuple[xr.Dataset, xr.DataArray, xr.DataArray, xr.DataArray, xr.DataArray]:
-    """Load the organic soil fluxes at the 2020/2024 blocks, pixel area, and GADM
-    layers, aligned to the organic soil grid (native 30m, so alignment is 1:1)."""
-    org = _load_zarr(organic_soil_uri)[ORGANIC_SOIL_SOURCE_VARS]
+    """Load the organic soil fluxes and extent mask at the 2020/2024 blocks, pixel
+    area, and GADM layers, aligned to the organic soil grid (native 30m, so
+    alignment is 1:1)."""
+    org = _load_zarr(organic_soil_uri)[
+        ORGANIC_SOIL_SOURCE_VARS + [ORGANIC_SOIL_MASK_VAR]
+    ]
     org = org.isel(year=BLOCK_YEAR_INDICES)
     org = clip(org, bbox)
     return (
@@ -127,6 +138,7 @@ def setup_organic_soil_compute(datasets: Tuple, expected_groups: Tuple) -> Tuple
     emissions = sum(org[var] for var in ORGANIC_SOIL_SOURCE_VARS)
     return setup_compute(
         emissions,
+        org[ORGANIC_SOIL_MASK_VAR],
         pixel_area,
         country,
         region,

--- a/pipelines/land_ghg_inventory/organic_soil_stages.py
+++ b/pipelines/land_ghg_inventory/organic_soil_stages.py
@@ -66,7 +66,7 @@ def setup_compute(
     pixel_area = pixel_area.fillna(0)
     layers = [
         (emissions.fillna(0) * pixel_area).astype("float64").rename(MEASURES[0]),
-        (pixel_area * xr.ones_like(emissions)).astype("float64").rename(AREA_LAYER),
+        pixel_area.astype("float64").rename(AREA_LAYER),
     ]
     cube = xr.concat(layers, dim="analysis_layer").assign_coords(
         analysis_layer=MEASURES + [AREA_LAYER]

--- a/pipelines/land_ghg_inventory/prefect_flows/land_ghg_inventory_flow.py
+++ b/pipelines/land_ghg_inventory/prefect_flows/land_ghg_inventory_flow.py
@@ -11,6 +11,8 @@ from pipelines.globals import (
     gadm_country_code_count,
     gadm_region_code_count,
     gadm_subregion_code_count,
+    land_ghg_inventory_organic_soil_zarr_uri,
+    land_ghg_inventory_soc_zarr_uri,
     land_ghg_inventory_vegetation_zarr_uri,
     pixel_area_zarr_uri,
     region_zarr_uri,
@@ -140,11 +142,125 @@ def land_ghg_inventory_agriculture(
     )(result_df, result_uri)
 
 
+@flow(name="Land GHG inventory mineral soil", retries=2, retry_delay_seconds=120)
+def land_ghg_inventory_mineral_soil(
+    version: str,
+    overwrite: bool = False,
+    bbox: Optional[Polygon] = None,
+) -> str:
+    """Land GHG inventory mineral soil organic carbon (SOC) zonal stats: gross
+    emissions / removals / net flux and area, admin-only (no year axis -- only
+    the 2015-2020 change interval is used, applied uniformly across all
+    vegetation years), rolled up to aoi_id.
+
+    ``bbox`` clips the reduce to one area for a laptop-friendly local run; the
+    result is written to a local parquet
+    (``admin-land_ghg_inventory-mineral_soil-{version}.parquet``) instead of the
+    canonical global S3 path (which would be a partial write)."""
+    if bbox is None:
+        result_uri = (
+            f"s3://{ANALYTICS_BUCKET}/zonal-statistics/land_ghg_inventory-mineral_soil/"
+            f"{version}/admin-land_ghg_inventory-mineral_soil.parquet"
+        )
+        if not overwrite and s3_uri_exists(result_uri):
+            return result_uri
+    else:
+        # local bbox test run
+        result_uri = f"admin-land_ghg_inventory-mineral_soil-{version}.parquet"
+
+    expected_groups = (
+        np.arange(gadm_country_code_count),
+        np.arange(gadm_region_code_count),
+        np.arange(gadm_subregion_code_count),
+    )
+    datasets = land_ghg_inventory_tasks.load_mineral_soil.with_options(
+        name="land_ghg_inventory-mineral_soil-load-data"
+    )(
+        land_ghg_inventory_soc_zarr_uri,
+        pixel_area_zarr_uri,
+        country_zarr_uri,
+        region_zarr_uri,
+        subregion_zarr_uri,
+        bbox,
+    )
+    compute_input = land_ghg_inventory_tasks.setup_mineral_soil_compute.with_options(
+        name="set-up-land_ghg_inventory-mineral_soil-compute"
+    )(datasets, expected_groups)
+    reduced = common_tasks.compute_zonal_stat.with_options(
+        name="land_ghg_inventory-mineral_soil-compute-zonal-stats"
+    )(*compute_input, funcname="sum")
+    result_df = land_ghg_inventory_tasks.mineral_soil_result_dataframe.with_options(
+        name="land_ghg_inventory-mineral_soil-postprocess-result"
+    )(reduced)
+    return common_tasks.save_result.with_options(
+        name="land_ghg_inventory-mineral_soil-save-result"
+    )(result_df, result_uri)
+
+
+@flow(name="Land GHG inventory organic soil", retries=2, retry_delay_seconds=120)
+def land_ghg_inventory_organic_soil(
+    version: str,
+    overwrite: bool = False,
+    bbox: Optional[Polygon] = None,
+) -> str:
+    """Land GHG inventory organic (peat) soil zonal stats: burned + drained gross
+    emissions and area, grouped by admin unit x ``interval_end_year`` (the source
+    zarr's native 2020/2024 block labels, covering the 2016-2020 and 2021-2024
+    vegetation periods respectively -- not broadcast to annual years), rolled up
+    to aoi_id.
+
+    ``bbox`` clips the reduce to one area for a laptop-friendly local run; the
+    result is written to a local parquet
+    (``admin-land_ghg_inventory-organic_soil-{version}.parquet``) instead of the
+    canonical global S3 path (which would be a partial write)."""
+    if bbox is None:
+        result_uri = (
+            f"s3://{ANALYTICS_BUCKET}/zonal-statistics/land_ghg_inventory-organic_soil/"
+            f"{version}/admin-land_ghg_inventory-organic_soil.parquet"
+        )
+        if not overwrite and s3_uri_exists(result_uri):
+            return result_uri
+    else:
+        # local bbox test run
+        result_uri = f"admin-land_ghg_inventory-organic_soil-{version}.parquet"
+
+    expected_groups = (
+        np.arange(gadm_country_code_count),
+        np.arange(gadm_region_code_count),
+        np.arange(gadm_subregion_code_count),
+        np.array([2020, 2024]),
+    )
+    datasets = land_ghg_inventory_tasks.load_organic_soil.with_options(
+        name="land_ghg_inventory-organic_soil-load-data"
+    )(
+        land_ghg_inventory_organic_soil_zarr_uri,
+        pixel_area_zarr_uri,
+        country_zarr_uri,
+        region_zarr_uri,
+        subregion_zarr_uri,
+        bbox,
+    )
+    compute_input = land_ghg_inventory_tasks.setup_organic_soil_compute.with_options(
+        name="set-up-land_ghg_inventory-organic_soil-compute"
+    )(datasets, expected_groups)
+    reduced = common_tasks.compute_zonal_stat.with_options(
+        name="land_ghg_inventory-organic_soil-compute-zonal-stats"
+    )(*compute_input, funcname="sum")
+    result_df = land_ghg_inventory_tasks.organic_soil_result_dataframe.with_options(
+        name="land_ghg_inventory-organic_soil-postprocess-result"
+    )(reduced)
+    return common_tasks.save_result.with_options(
+        name="land_ghg_inventory-organic_soil-save-result"
+    )(result_df, result_uri)
+
+
 # component name -> its subflow. Add new components (e.g. soil) here to expose
 # them through `component`, without touching run_updates.py.
 COMPONENT_FLOWS = {
     "vegetation": land_ghg_inventory_vegetation,
     "agriculture": land_ghg_inventory_agriculture,
+    "mineral_soil": land_ghg_inventory_mineral_soil,
+    "organic_soil": land_ghg_inventory_organic_soil,
 }
 ALL_COMPONENTS = tuple(COMPONENT_FLOWS)
 

--- a/pipelines/land_ghg_inventory/prefect_flows/land_ghg_inventory_tasks.py
+++ b/pipelines/land_ghg_inventory/prefect_flows/land_ghg_inventory_tasks.py
@@ -5,7 +5,12 @@ import xarray as xr
 from prefect import task
 from shapely.geometry import Polygon
 
-from pipelines.land_ghg_inventory import agriculture_stages, vegetation_stages
+from pipelines.land_ghg_inventory import (
+    agriculture_stages,
+    mineral_soil_stages,
+    organic_soil_stages,
+    vegetation_stages,
+)
 from pipelines.land_ghg_inventory.create_agriculture_zarr import (
     create_agriculture_zarr,
 )
@@ -61,3 +66,51 @@ def setup_agriculture_compute(datasets: Tuple, expected_groups: Tuple) -> Tuple:
 @task
 def agriculture_result_dataframe(reduced: xr.DataArray) -> pd.DataFrame:
     return agriculture_stages.agriculture_result_dataframe(reduced)
+
+
+@task
+def load_mineral_soil(
+    soc_uri: str,
+    pixel_area_uri: str,
+    country_uri: str,
+    region_uri: str,
+    subregion_uri: str,
+    bbox: Optional[Polygon] = None,
+) -> Tuple[xr.Dataset, xr.DataArray, xr.DataArray, xr.DataArray, xr.DataArray]:
+    return mineral_soil_stages.load_data(
+        soc_uri, pixel_area_uri, country_uri, region_uri, subregion_uri, bbox
+    )
+
+
+@task
+def setup_mineral_soil_compute(datasets: Tuple, expected_groups: Tuple) -> Tuple:
+    return mineral_soil_stages.setup_mineral_soil_compute(datasets, expected_groups)
+
+
+@task
+def mineral_soil_result_dataframe(reduced: xr.DataArray) -> pd.DataFrame:
+    return mineral_soil_stages.mineral_soil_result_dataframe(reduced)
+
+
+@task
+def load_organic_soil(
+    organic_soil_uri: str,
+    pixel_area_uri: str,
+    country_uri: str,
+    region_uri: str,
+    subregion_uri: str,
+    bbox: Optional[Polygon] = None,
+) -> Tuple[xr.Dataset, xr.DataArray, xr.DataArray, xr.DataArray, xr.DataArray]:
+    return organic_soil_stages.load_data(
+        organic_soil_uri, pixel_area_uri, country_uri, region_uri, subregion_uri, bbox
+    )
+
+
+@task
+def setup_organic_soil_compute(datasets: Tuple, expected_groups: Tuple) -> Tuple:
+    return organic_soil_stages.setup_organic_soil_compute(datasets, expected_groups)
+
+
+@task
+def organic_soil_result_dataframe(reduced: xr.DataArray) -> pd.DataFrame:
+    return organic_soil_stages.organic_soil_result_dataframe(reduced)

--- a/pipelines/run_updates.py
+++ b/pipelines/run_updates.py
@@ -92,6 +92,8 @@ LAND_GHG_INVENTORY_COMPONENT = {
     "land_ghg_inventory_update": None,
     "land_ghg_inventory_vegetation_update": "vegetation",
     "land_ghg_inventory_agriculture_update": "agriculture",
+    "land_ghg_inventory_mineral_soil_update": "mineral_soil",
+    "land_ghg_inventory_organic_soil_update": "organic_soil",
 }
 
 
@@ -129,6 +131,8 @@ class UpdateFlow(str, Enum):
     LAND_GHG_INVENTORY_UPDATE = "land_ghg_inventory_update"
     LAND_GHG_INVENTORY_VEGETATION_UPDATE = "land_ghg_inventory_vegetation_update"
     LAND_GHG_INVENTORY_AGRICULTURE_UPDATE = "land_ghg_inventory_agriculture_update"
+    LAND_GHG_INVENTORY_MINERAL_SOIL_UPDATE = "land_ghg_inventory_mineral_soil_update"
+    LAND_GHG_INVENTORY_ORGANIC_SOIL_UPDATE = "land_ghg_inventory_organic_soil_update"
 
 
 update_flows = {
@@ -138,6 +142,8 @@ update_flows = {
     UpdateFlow.LAND_GHG_INVENTORY_UPDATE: run_land_ghg_inventory_update,
     UpdateFlow.LAND_GHG_INVENTORY_VEGETATION_UPDATE: run_land_ghg_inventory_update,
     UpdateFlow.LAND_GHG_INVENTORY_AGRICULTURE_UPDATE: run_land_ghg_inventory_update,
+    UpdateFlow.LAND_GHG_INVENTORY_MINERAL_SOIL_UPDATE: run_land_ghg_inventory_update,
+    UpdateFlow.LAND_GHG_INVENTORY_ORGANIC_SOIL_UPDATE: run_land_ghg_inventory_update,
 }
 
 # flows that produce versioned outputs and therefore require an explicit version
@@ -146,6 +152,8 @@ VERSION_REQUIRED_FLOWS = (
     UpdateFlow.LAND_GHG_INVENTORY_UPDATE,
     UpdateFlow.LAND_GHG_INVENTORY_VEGETATION_UPDATE,
     UpdateFlow.LAND_GHG_INVENTORY_AGRICULTURE_UPDATE,
+    UpdateFlow.LAND_GHG_INVENTORY_MINERAL_SOIL_UPDATE,
+    UpdateFlow.LAND_GHG_INVENTORY_ORGANIC_SOIL_UPDATE,
 )
 
 # flow_name values that route into run_land_ghg_inventory_update
@@ -153,6 +161,8 @@ LAND_GHG_INVENTORY_FLOWS = (
     UpdateFlow.LAND_GHG_INVENTORY_UPDATE,
     UpdateFlow.LAND_GHG_INVENTORY_VEGETATION_UPDATE,
     UpdateFlow.LAND_GHG_INVENTORY_AGRICULTURE_UPDATE,
+    UpdateFlow.LAND_GHG_INVENTORY_MINERAL_SOIL_UPDATE,
+    UpdateFlow.LAND_GHG_INVENTORY_ORGANIC_SOIL_UPDATE,
 )
 
 

--- a/pipelines/test/integration/land_ghg_inventory/test_mineral_soil_flow.py
+++ b/pipelines/test/integration/land_ghg_inventory/test_mineral_soil_flow.py
@@ -1,0 +1,62 @@
+"""Integration test: the mineral_soil stages run against the real global zarr,
+clipped to São Tomé & Príncipe, must reproduce known reference totals. Exercises
+the same chain the flow runs (load -> setup -> reduce -> result dataframe), minus
+the global scope and the S3 write.
+"""
+
+import numpy as np
+import pytest
+from shapely.geometry import box
+
+from pipelines.globals import (
+    country_zarr_uri,
+    gadm_country_code_count,
+    gadm_region_code_count,
+    gadm_subregion_code_count,
+    land_ghg_inventory_soc_zarr_uri,
+    pixel_area_zarr_uri,
+    region_zarr_uri,
+    subregion_zarr_uri,
+)
+from pipelines.land_ghg_inventory import mineral_soil_stages
+from pipelines.prefect_flows import common_stages
+
+# São Tomé & Príncipe: both islands, ocean elsewhere (isolated -> clean bbox).
+STP_BBOX = box(6.4, -0.05, 7.5, 1.8)
+
+# Reference totals for STP, computed directly against the real zarr (no reduce over
+# the full gadm_*_code_count admin codes changes these, since STP's own codes are
+# within range). Emissions/removals/net flux are genuinely zero for STP over the
+# 2015-2020 change interval -- a small island nation with minimal recorded mineral
+# SOC change in this dataset, not a computation bug (verified against a nonzero
+# Amazon bbox during development).
+EXPECTED_AREA_HA = 100217.98772067629
+
+
+def test_stp_reproduces_reference_totals():
+    datasets = mineral_soil_stages.load_data(
+        land_ghg_inventory_soc_zarr_uri,
+        pixel_area_zarr_uri,
+        country_zarr_uri,
+        region_zarr_uri,
+        subregion_zarr_uri,
+        bbox=STP_BBOX,
+    )
+    expected_groups = (
+        np.arange(gadm_country_code_count),
+        np.arange(gadm_region_code_count),
+        np.arange(gadm_subregion_code_count),
+    )
+    cube, groupbys, out_expected_groups = (
+        mineral_soil_stages.setup_mineral_soil_compute(datasets, expected_groups)
+    )
+    reduced = common_stages.compute(cube, groupbys, out_expected_groups, "sum")
+    df = mineral_soil_stages.mineral_soil_result_dataframe(reduced)
+
+    country = df[df["aoi_id"] == "STP"]
+    assert not country.empty
+    row = country.iloc[0]
+    assert row["gross_emissions_MgCO2e"] == 0.0
+    assert row["gross_removals_MgCO2"] == 0.0
+    assert row["net_flux_MgCO2e"] == 0.0
+    assert row["area_ha"] == pytest.approx(EXPECTED_AREA_HA, rel=0.02)

--- a/pipelines/test/integration/land_ghg_inventory/test_organic_soil_flow.py
+++ b/pipelines/test/integration/land_ghg_inventory/test_organic_soil_flow.py
@@ -1,15 +1,11 @@
 """Integration test: the organic_soil stages run against the real global zarr,
-clipped to São Tomé & Príncipe, must reproduce known reference totals. Exercises
-the same chain the flow runs (load -> setup -> reduce -> result dataframe), minus
+clipped to Singapore, must reproduce known reference emissions. Exercises the
+same chain the flow runs (load -> setup -> reduce -> result dataframe), minus
 the global scope and the S3 write.
-
-Only emissions are asserted here, not area_ha: STP has zero organic_soil-extent
-pixels in the current zarr, so after the area-mask fix its masked area is 0 ha,
-not the country's total land area -- emissions are unaffected by that mask (they
-were already zero outside the extent) and stay a stable, meaningful check.
 """
 
 import numpy as np
+import pytest
 from shapely.geometry import box
 
 from pipelines.globals import (
@@ -25,18 +21,26 @@ from pipelines.globals import (
 from pipelines.land_ghg_inventory import organic_soil_stages
 from pipelines.prefect_flows import common_stages
 
-# São Tomé & Príncipe: both islands, ocean elsewhere (isolated -> clean bbox).
-STP_BBOX = box(6.4, -0.05, 7.5, 1.8)
+# Singapore: compact city-state, isolated by water -> clean bbox.
+SGP_BBOX = box(103.6, 1.15, 104.1, 1.48)
+
+# Reference emissions for SGP, computed directly against the real zarr (no
+# reduce over the full gadm_*_code_count admin codes changes these, since SGP's
+# own codes are within range).
+EXPECTED_EMISSIONS_MgCO2e = {
+    2020: 45987.43,
+    2024: 67217.00,
+}
 
 
-def test_stp_reproduces_reference_totals():
+def test_sgp_reproduces_reference_totals():
     datasets = organic_soil_stages.load_data(
         land_ghg_inventory_organic_soil_zarr_uri,
         pixel_area_zarr_uri,
         country_zarr_uri,
         region_zarr_uri,
         subregion_zarr_uri,
-        bbox=STP_BBOX,
+        bbox=SGP_BBOX,
     )
     expected_groups = (
         np.arange(gadm_country_code_count),
@@ -50,9 +54,11 @@ def test_stp_reproduces_reference_totals():
     reduced = common_stages.compute(cube, groupbys, out_expected_groups, "sum")
     df = organic_soil_stages.organic_soil_result_dataframe(reduced)
 
-    country = df[df["aoi_id"] == "STP"]
+    country = df[df["aoi_id"] == "SGP"]
     assert not country.empty
     assert set(country["interval_end_year"]) == {2020, 2024}
     for year in (2020, 2024):
         row = country[country["interval_end_year"] == year].iloc[0]
-        assert row["gross_emissions_MgCO2e"] == 0.0
+        assert row["gross_emissions_MgCO2e"] == pytest.approx(
+            EXPECTED_EMISSIONS_MgCO2e[year], rel=0.02
+        )

--- a/pipelines/test/integration/land_ghg_inventory/test_organic_soil_flow.py
+++ b/pipelines/test/integration/land_ghg_inventory/test_organic_soil_flow.py
@@ -1,0 +1,63 @@
+"""Integration test: the organic_soil stages run against the real global zarr,
+clipped to São Tomé & Príncipe, must reproduce known reference totals. Exercises
+the same chain the flow runs (load -> setup -> reduce -> result dataframe), minus
+the global scope and the S3 write.
+"""
+
+import numpy as np
+import pytest
+from shapely.geometry import box
+
+from pipelines.globals import (
+    country_zarr_uri,
+    gadm_country_code_count,
+    gadm_region_code_count,
+    gadm_subregion_code_count,
+    land_ghg_inventory_organic_soil_zarr_uri,
+    pixel_area_zarr_uri,
+    region_zarr_uri,
+    subregion_zarr_uri,
+)
+from pipelines.land_ghg_inventory import organic_soil_stages
+from pipelines.prefect_flows import common_stages
+
+# São Tomé & Príncipe: both islands, ocean elsewhere (isolated -> clean bbox).
+STP_BBOX = box(6.4, -0.05, 7.5, 1.8)
+
+# Reference totals for STP, computed directly against the real zarr (no reduce over
+# the full gadm_*_code_count admin codes changes these, since STP's own codes are
+# within range). Emissions are genuinely zero for STP in both blocks -- a small
+# island nation with no recorded organic/peat soil in this dataset, not a
+# computation bug (verified against a nonzero Indonesian peatland bbox during
+# development).
+EXPECTED_AREA_HA = 100217.98772067629
+
+
+def test_stp_reproduces_reference_totals():
+    datasets = organic_soil_stages.load_data(
+        land_ghg_inventory_organic_soil_zarr_uri,
+        pixel_area_zarr_uri,
+        country_zarr_uri,
+        region_zarr_uri,
+        subregion_zarr_uri,
+        bbox=STP_BBOX,
+    )
+    expected_groups = (
+        np.arange(gadm_country_code_count),
+        np.arange(gadm_region_code_count),
+        np.arange(gadm_subregion_code_count),
+        np.array([2020, 2024]),
+    )
+    cube, groupbys, out_expected_groups = (
+        organic_soil_stages.setup_organic_soil_compute(datasets, expected_groups)
+    )
+    reduced = common_stages.compute(cube, groupbys, out_expected_groups, "sum")
+    df = organic_soil_stages.organic_soil_result_dataframe(reduced)
+
+    country = df[df["aoi_id"] == "STP"]
+    assert not country.empty
+    assert set(country["interval_end_year"]) == {2020, 2024}
+    for year in (2020, 2024):
+        row = country[country["interval_end_year"] == year].iloc[0]
+        assert row["gross_emissions_MgCO2e"] == 0.0
+        assert row["area_ha"] == pytest.approx(EXPECTED_AREA_HA, rel=0.02)

--- a/pipelines/test/integration/land_ghg_inventory/test_organic_soil_flow.py
+++ b/pipelines/test/integration/land_ghg_inventory/test_organic_soil_flow.py
@@ -2,10 +2,14 @@
 clipped to São Tomé & Príncipe, must reproduce known reference totals. Exercises
 the same chain the flow runs (load -> setup -> reduce -> result dataframe), minus
 the global scope and the S3 write.
+
+Only emissions are asserted here, not area_ha: STP has zero organic_soil-extent
+pixels in the current zarr, so after the area-mask fix its masked area is 0 ha,
+not the country's total land area -- emissions are unaffected by that mask (they
+were already zero outside the extent) and stay a stable, meaningful check.
 """
 
 import numpy as np
-import pytest
 from shapely.geometry import box
 
 from pipelines.globals import (
@@ -23,14 +27,6 @@ from pipelines.prefect_flows import common_stages
 
 # São Tomé & Príncipe: both islands, ocean elsewhere (isolated -> clean bbox).
 STP_BBOX = box(6.4, -0.05, 7.5, 1.8)
-
-# Reference totals for STP, computed directly against the real zarr (no reduce over
-# the full gadm_*_code_count admin codes changes these, since STP's own codes are
-# within range). Emissions are genuinely zero for STP in both blocks -- a small
-# island nation with no recorded organic/peat soil in this dataset, not a
-# computation bug (verified against a nonzero Indonesian peatland bbox during
-# development).
-EXPECTED_AREA_HA = 100217.98772067629
 
 
 def test_stp_reproduces_reference_totals():
@@ -60,4 +56,3 @@ def test_stp_reproduces_reference_totals():
     for year in (2020, 2024):
         row = country[country["interval_end_year"] == year].iloc[0]
         assert row["gross_emissions_MgCO2e"] == 0.0
-        assert row["area_ha"] == pytest.approx(EXPECTED_AREA_HA, rel=0.02)

--- a/pipelines/test/unit/land_ghg_inventory/conftest.py
+++ b/pipelines/test/unit/land_ghg_inventory/conftest.py
@@ -146,13 +146,17 @@ def synthetic_organic_soil_datasets():
     """Tiny 2-block, 2x2 scene with a year dim of exactly 2 values [2020, 2024]
 
     Per-hectare burned/drained fluxes are constant (burned=6, drained=4, so
-    emissions=10) and each 2 ha pixel maps to the same admin unit, so grouped
-    per-pixel totals are known: emissions=20, area=2, for each block year.
+    emissions=10) on 3 of the 4 pixels; the 4th pixel is outside the
+    organic_soil extent mask and has zero burned/drained (matching the real
+    zarr's invariant that fluxes are zero outside the mask). Each 2 ha pixel
+    maps to the same admin unit, so grouped per-pixel totals are known:
+    emissions=60 (3 pixels x 20), area=6 ha (3 pixels x 2 ha, mask excludes
+    the 4th), for each block year.
     """
     coords3 = {"year": [2020, 2024], "y": [0.0, 1.0], "x": [0.0, 1.0]}
 
-    def cube(value):
-        arr = np.full((2, 2, 2), value, dtype="float32")
+    def cube3(values):
+        arr = np.array([values, values], dtype="float32")
         return xr.DataArray(
             da.from_array(arr, chunks=(1, 2, 2)),
             dims=["year", "y", "x"],
@@ -161,8 +165,9 @@ def synthetic_organic_soil_datasets():
 
     org = xr.Dataset(
         {
-            "burned_total_Mg_CO2e_ha_yr": cube(6.0),
-            "drained_total_Mg_CO2e_ha_yr": cube(4.0),
+            "burned_total_Mg_CO2e_ha_yr": cube3([[6.0, 6.0], [6.0, 0.0]]),
+            "drained_total_Mg_CO2e_ha_yr": cube3([[4.0, 4.0], [4.0, 0.0]]),
+            "organic_soil": cube3([[1, 1], [1, 0]]).astype("uint8"),
         }
     )
 

--- a/pipelines/test/unit/land_ghg_inventory/conftest.py
+++ b/pipelines/test/unit/land_ghg_inventory/conftest.py
@@ -102,3 +102,90 @@ def synthetic_agriculture_datasets():
         np.array([0, 1]),
     )
     return datasets, expected_groups
+
+
+@pytest.fixture
+def synthetic_mineral_soil_datasets():
+    """Tiny 2x2 scene, single time slice already selected (no year axis).
+
+    Per-hectare SOC fluxes are constant (emis=10, rem=-4, net=6) and each 2 ha
+    pixel maps to the same admin unit, so grouped per-pixel totals are known:
+    emis=20, rem=-8, net=12, area=2.
+    """
+    coords2 = {"y": [0.0, 1.0], "x": [0.0, 1.0]}
+
+    def layer(values, dtype="float32"):
+        return xr.DataArray(
+            da.from_array(np.array(values, dtype=dtype), chunks=(2, 2)),
+            dims=["y", "x"],
+            coords=coords2,
+        )
+
+    soc = xr.Dataset(
+        {
+            "gross_emissions_MgCO2e": layer([[10.0, 10.0], [10.0, 10.0]]),
+            "gross_removals_MgCO2": layer([[-4.0, -4.0], [-4.0, -4.0]]),
+            "net_flux_MgCO2e": layer([[6.0, 6.0], [6.0, 6.0]]),
+        }
+    )
+    pixel_area = layer([[2.0, 2.0], [2.0, 2.0]], "float64")
+    country = layer([[76, 76], [76, 76]], "int32")  # 76 -> BRA
+    region = layer([[1, 1], [1, 1]], "int32")
+    subregion = layer([[1, 1], [1, 1]], "int32")
+
+    datasets = (soc, pixel_area, country, region, subregion)
+    expected_groups = (
+        np.array([76]),
+        np.array([1]),
+        np.array([1]),
+    )
+    return datasets, expected_groups
+
+
+@pytest.fixture
+def synthetic_organic_soil_datasets():
+    """Tiny 2-block, 2x2 scene with a year dim of exactly 2 values [2020, 2024]
+
+    Per-hectare burned/drained fluxes are constant (burned=6, drained=4, so
+    emissions=10) and each 2 ha pixel maps to the same admin unit, so grouped
+    per-pixel totals are known: emissions=20, area=2, for each block year.
+    """
+    coords3 = {"year": [2020, 2024], "y": [0.0, 1.0], "x": [0.0, 1.0]}
+
+    def cube(value):
+        arr = np.full((2, 2, 2), value, dtype="float32")
+        return xr.DataArray(
+            da.from_array(arr, chunks=(1, 2, 2)),
+            dims=["year", "y", "x"],
+            coords=coords3,
+        )
+
+    org = xr.Dataset(
+        {
+            "burned_total_Mg_CO2e_ha_yr": cube(6.0),
+            "drained_total_Mg_CO2e_ha_yr": cube(4.0),
+        }
+    )
+
+    coords2 = {"y": [0.0, 1.0], "x": [0.0, 1.0]}
+
+    def layer(values, dtype):
+        return xr.DataArray(
+            da.from_array(np.array(values, dtype=dtype), chunks=(2, 2)),
+            dims=["y", "x"],
+            coords=coords2,
+        )
+
+    pixel_area = layer([[2.0, 2.0], [2.0, 2.0]], "float64")
+    country = layer([[76, 76], [76, 76]], "int32")  # 76 -> BRA
+    region = layer([[1, 1], [1, 1]], "int32")
+    subregion = layer([[1, 1], [1, 1]], "int32")
+
+    datasets = (org, pixel_area, country, region, subregion)
+    expected_groups = (
+        np.array([76]),
+        np.array([1]),
+        np.array([1]),
+        np.array([2020, 2024]),
+    )
+    return datasets, expected_groups

--- a/pipelines/test/unit/land_ghg_inventory/test_mineral_soil_result_dataframe.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_mineral_soil_result_dataframe.py
@@ -1,0 +1,39 @@
+from pipelines.land_ghg_inventory import mineral_soil_stages
+from pipelines.prefect_flows import common_stages
+
+
+def test_mineral_soil_result_dataframe_rolls_up(synthetic_mineral_soil_datasets):
+    datasets, expected_groups = synthetic_mineral_soil_datasets
+
+    cube, groupbys, out_expected_groups = (
+        mineral_soil_stages.setup_mineral_soil_compute(datasets, expected_groups)
+    )
+    reduced = common_stages.compute(cube, groupbys, out_expected_groups, "sum")
+    df = mineral_soil_stages.mineral_soil_result_dataframe(reduced)
+
+    assert {
+        "aoi_id",
+        "aoi_type",
+        "gross_emissions_MgCO2e",
+        "gross_removals_MgCO2",
+        "net_flux_MgCO2e",
+        "area_ha",
+    }.issubset(df.columns)
+    assert "year" not in df.columns
+    assert "land_state_class" not in df.columns
+    assert "category" not in df.columns
+    assert set(df["aoi_type"]) == {"admin"}
+
+    # subregion-level totals: all 4 pixels, one row (no categorical axis)
+    subregion_row = df[df.aoi_id == "BRA.1.1"].iloc[0]
+    assert subregion_row.gross_emissions_MgCO2e == 80.0
+    assert subregion_row.gross_removals_MgCO2 == -32.0
+    assert subregion_row.net_flux_MgCO2e == 48.0
+    assert subregion_row.area_ha == 8.0
+
+    # country-level roll-up equals the same total (only one admin unit present)
+    country_row = df[df.aoi_id == "BRA"].iloc[0]
+    assert country_row.gross_emissions_MgCO2e == 80.0
+    assert country_row.gross_removals_MgCO2 == -32.0
+    assert country_row.net_flux_MgCO2e == 48.0
+    assert country_row.area_ha == 8.0

--- a/pipelines/test/unit/land_ghg_inventory/test_mineral_soil_setup_compute.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_mineral_soil_setup_compute.py
@@ -1,0 +1,30 @@
+from pipelines.land_ghg_inventory import mineral_soil_stages
+
+
+def test_setup_mineral_soil_compute_builds_measure_cube_and_groupbys(
+    synthetic_mineral_soil_datasets,
+):
+    datasets, expected_groups = synthetic_mineral_soil_datasets
+
+    cube, groupbys, out_expected_groups = (
+        mineral_soil_stages.setup_mineral_soil_compute(datasets, expected_groups)
+    )
+
+    assert list(cube.analysis_layer.values) == [
+        "gross_emissions_MgCO2e",
+        "gross_removals_MgCO2",
+        "net_flux_MgCO2e",
+        "area_ha",
+    ]
+    # per-hectare * pixel_area (2 ha) -> per-pixel totals
+    emissions = cube.sel(analysis_layer="gross_emissions_MgCO2e").values
+    assert (emissions == 20.0).all()
+    removals = cube.sel(analysis_layer="gross_removals_MgCO2").values
+    assert (removals == -8.0).all()
+    net = cube.sel(analysis_layer="net_flux_MgCO2e").values
+    assert (net == 12.0).all()
+    area = cube.sel(analysis_layer="area_ha").values
+    assert (area == 2.0).all()
+
+    assert [g.name for g in groupbys] == ["country", "region", "subregion"]
+    assert out_expected_groups is expected_groups

--- a/pipelines/test/unit/land_ghg_inventory/test_organic_soil_result_dataframe.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_organic_soil_result_dataframe.py
@@ -1,0 +1,40 @@
+from pipelines.land_ghg_inventory import organic_soil_stages
+from pipelines.prefect_flows import common_stages
+
+
+def test_organic_soil_result_dataframe_rolls_up(synthetic_organic_soil_datasets):
+    datasets, expected_groups = synthetic_organic_soil_datasets
+
+    cube, groupbys, out_expected_groups = (
+        organic_soil_stages.setup_organic_soil_compute(datasets, expected_groups)
+    )
+    reduced = common_stages.compute(cube, groupbys, out_expected_groups, "sum")
+    df = organic_soil_stages.organic_soil_result_dataframe(reduced)
+
+    assert {
+        "aoi_id",
+        "aoi_type",
+        "interval_end_year",
+        "gross_emissions_MgCO2e",
+        "area_ha",
+    }.issubset(df.columns)
+    assert "year" not in df.columns
+    assert "land_state_class" not in df.columns
+    assert "category" not in df.columns
+    assert set(df["aoi_type"]) == {"admin"}
+    # native block labels persisted as-is, not expanded to vegetation years
+    assert set(df["interval_end_year"]) == {2020, 2024}
+
+    # subregion-level totals: all 4 pixels, one row per block year
+    subregion_rows = df[df.aoi_id == "BRA.1.1"]
+    for year in (2020, 2024):
+        row = subregion_rows[subregion_rows.interval_end_year == year].iloc[0]
+        assert row.gross_emissions_MgCO2e == 80.0
+        assert row.area_ha == 8.0
+
+    # country-level roll-up equals the same total (only one admin unit present)
+    country_rows = df[df.aoi_id == "BRA"]
+    for year in (2020, 2024):
+        row = country_rows[country_rows.interval_end_year == year].iloc[0]
+        assert row.gross_emissions_MgCO2e == 80.0
+        assert row.area_ha == 8.0

--- a/pipelines/test/unit/land_ghg_inventory/test_organic_soil_result_dataframe.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_organic_soil_result_dataframe.py
@@ -25,16 +25,17 @@ def test_organic_soil_result_dataframe_rolls_up(synthetic_organic_soil_datasets)
     # native block labels persisted as-is, not expanded to vegetation years
     assert set(df["interval_end_year"]) == {2020, 2024}
 
-    # subregion-level totals: all 4 pixels, one row per block year
+    # subregion-level totals: 3 of 4 pixels are in the organic_soil mask (the
+    # 4th has zero flux and is excluded from area), one row per block year
     subregion_rows = df[df.aoi_id == "BRA.1.1"]
     for year in (2020, 2024):
         row = subregion_rows[subregion_rows.interval_end_year == year].iloc[0]
-        assert row.gross_emissions_MgCO2e == 80.0
-        assert row.area_ha == 8.0
+        assert row.gross_emissions_MgCO2e == 60.0
+        assert row.area_ha == 6.0
 
     # country-level roll-up equals the same total (only one admin unit present)
     country_rows = df[df.aoi_id == "BRA"]
     for year in (2020, 2024):
         row = country_rows[country_rows.interval_end_year == year].iloc[0]
-        assert row.gross_emissions_MgCO2e == 80.0
-        assert row.area_ha == 8.0
+        assert row.gross_emissions_MgCO2e == 60.0
+        assert row.area_ha == 6.0

--- a/pipelines/test/unit/land_ghg_inventory/test_organic_soil_setup_compute.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_organic_soil_setup_compute.py
@@ -1,0 +1,27 @@
+from pipelines.land_ghg_inventory import organic_soil_stages
+
+
+def test_setup_organic_soil_compute_builds_measure_cube_and_groupbys(
+    synthetic_organic_soil_datasets,
+):
+    datasets, expected_groups = synthetic_organic_soil_datasets
+
+    cube, groupbys, out_expected_groups = (
+        organic_soil_stages.setup_organic_soil_compute(datasets, expected_groups)
+    )
+
+    assert list(cube.analysis_layer.values) == ["gross_emissions_MgCO2e", "area_ha"]
+    # burned (6) + drained (4) = 10 per-hectare, * pixel_area (2 ha) -> 20 per-pixel
+    emissions = cube.sel(analysis_layer="gross_emissions_MgCO2e").values
+    assert (emissions == 20.0).all()
+    area = cube.sel(analysis_layer="area_ha").values
+    assert (area == 2.0).all()
+    assert list(cube.year.values) == [2020, 2024]
+
+    assert [g.name for g in groupbys] == [
+        "country",
+        "region",
+        "subregion",
+        "interval_end_year",
+    ]
+    assert out_expected_groups is expected_groups

--- a/pipelines/test/unit/land_ghg_inventory/test_organic_soil_setup_compute.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_organic_soil_setup_compute.py
@@ -11,11 +11,13 @@ def test_setup_organic_soil_compute_builds_measure_cube_and_groupbys(
     )
 
     assert list(cube.analysis_layer.values) == ["gross_emissions_MgCO2e", "area_ha"]
-    # burned (6) + drained (4) = 10 per-hectare, * pixel_area (2 ha) -> 20 per-pixel
+    # burned (6) + drained (4) = 10 per-hectare, * pixel_area (2 ha) -> 20 per-pixel,
+    # 0 on the pixel outside the organic_soil mask (fluxes are already zero there)
     emissions = cube.sel(analysis_layer="gross_emissions_MgCO2e").values
-    assert (emissions == 20.0).all()
+    assert (emissions == [[20.0, 20.0], [20.0, 0.0]]).all()
+    # area_ha is masked by organic_soil extent: 2 ha per in-mask pixel, 0 outside it
     area = cube.sel(analysis_layer="area_ha").values
-    assert (area == 2.0).all()
+    assert (area == [[2.0, 2.0], [2.0, 0.0]]).all()
     assert list(cube.year.values) == [2020, 2024]
 
     assert [g.name for g in groupbys] == [

--- a/terraform/prefect.tf
+++ b/terraform/prefect.tf
@@ -160,7 +160,7 @@ resource "prefect_deployment" "gnw_zonal_stats_update" {
         title   = "Flow Name"
         type    = "string"
         default = "dist_update"
-        enum    = ["dist_update", "tcl_update", "integrated_alerts_update", "land_ghg_inventory_update", "land_ghg_inventory_vegetation_update", "land_ghg_inventory_agriculture_update"]
+        enum    = ["dist_update", "tcl_update", "integrated_alerts_update", "land_ghg_inventory_update", "land_ghg_inventory_vegetation_update", "land_ghg_inventory_agriculture_update", "land_ghg_inventory_mineral_soil_update", "land_ghg_inventory_organic_soil_update"]
       }
     }
   })


### PR DESCRIPTION


## Summary

Adds two new components to the `land_ghg_inventory` pipeline — `mineral_soil` and `organic_soil` — alongside the existing `vegetation` and `agriculture` components. Each reads its own source zarr, converts per-hectare fluxes to per-pixel totals, aggregates to GADM admin units, and writes its own parquet, following the same pattern already established for `vegetation`/`agriculture`.

## New parquet outputs

**Mineral soil** — `s3://lcl-analytics/zonal-statistics/land_ghg_inventory-mineral_soil/{version}/admin-land_ghg_inventory-mineral_soil.parquet`

One row per `aoi_id`. A single static snapshot (the 2015–2020 SOC change interval) — no year axis:

| column | type | notes |
|---|---|---|
| `aoi_id` | str | e.g. `"BRA"`, `"BRA.1"`, `"BRA.1.1"` |
| `aoi_type` | str | always `"admin"` |
| `gross_emissions_MgCO2e` | float | |
| `gross_removals_MgCO2` | float | |
| `net_flux_MgCO2e` | float | |
| `area_ha` | float | |

**Organic soil** — `s3://lcl-analytics/zonal-statistics/land_ghg_inventory-organic_soil/{version}/admin-land_ghg_inventory-organic_soil.parquet`

One row per `aoi_id` x `interval_end_year`. Two native 5-year blocks are persisted as-is (`2020` covers 2016–2020, `2024` covers 2021–2024) — not broadcast to annual figures:

| column | type | notes |
|---|---|---|
| `aoi_id` | str | |
| `aoi_type` | str | always `"admin"` |
| `interval_end_year` | int | `2020` \| `2024` |
| `gross_emissions_MgCO2e` | float | burned + drained, summed |
| `area_ha` | float | restricted to organic-soil-extent pixels |

## Downstream API payload

These parquets are read directly by the `land_ghg_inventory` analytics endpoint (see the companion API PR), which serves each one as a column-oriented table under `result`, alongside the existing `vegetation`/`agriculture` tables:

```json
{
  "data": {
    "result": {
      "vegetation": {
        "aoi_id": ["BRA.1", "BRA.1"],
        "aoi_type": ["admin", "admin"],
        "land_state_class": ["tree_loss", "tree_gain"],
        "year": [2016, 2016],
        "gross_emissions_MgCO2e": [438480933.0, 0.0],
        "gross_removals_MgCO2": [-29404371.0, -3213337.0],
        "net_flux_MgCO2e": [409076565.0, -3213337.0],
        "area_ha": [1086087.0, 518423.0]
      },
      "agriculture": {
        "aoi_id": ["BRA.1"],
        "aoi_type": ["admin"],
        "category": ["cropland"],
        "gross_emissions_MgCO2e": [123234500000.0]
      },
      "mineral_soil": {
        "aoi_id": ["BRA.1"],
        "aoi_type": ["admin"],
        "gross_emissions_MgCO2e": [4533948.0],
        "gross_removals_MgCO2": [-2740651.0],
        "net_flux_MgCO2e": [1793298.0],
        "area_ha": [8509086.0]
      },
      "organic_soil": {
        "aoi_id": ["BRA.1", "BRA.1"],
        "aoi_type": ["admin", "admin"],
        "interval_end_year": [2020, 2024],
        "gross_emissions_MgCO2e": [11.6, 313515.6],
        "area_ha": [8509086.0, 8509086.0]
      }
    },
    "metadata": { "aoi": { "type": "admin", "ids": ["BRA.1"] } },
    "message": "Analysis completed successfully.",
    "status": "saved"
  },
  "status": "success"
}
```

Each table's columns map 1:1 to its parquet's schema. `mineral_soil` and `organic_soil` are flat, top-level siblings of `vegetation`/`agriculture` — not nested under a parent `soil` key — since each has an independent schema.

## Key decisions

- **Two components, not one.** Mineral and organic soil have different measures (3 vs. 1) and different temporal shapes (no year axis vs. 2 native blocks), so merging them into a single `soil` parquet with a category discriminator would have produced a sparse/ragged table. Kept as two independent components/parquets, matching the existing one-component-per-source-zarr precedent.
- **No broadcasting to annual years at write time.** Both sources are static/blocky at the source (a single SOC interval; two 5-year organic-soil blocks). Mapping those onto vegetation's 9 annual years is a derivative join, not a fact worth baking into storage — persisted at native resolution, left for downstream consumers to broadcast.
- **`area_ha` is masked to organic-soil extent.** The organic soil source zarr carries an explicit `organic_soil` extent variable; `area_ha` is computed as `pixel_area` restricted to that mask, not total admin-unit area.

## Verification

- New unit tests (synthetic fixtures) for both components' setup/compute and result-dataframe logic.
- New integration tests against the real global zarrs, clipped to São Tomé & Príncipe.
- Cross-checked mineral_soil and organic_soil outputs against an independently-produced reference LULUCF table across a broad country spread (islands, large countries, high/low latitude) — emissions/removals/net flux match closely for the large majority of countries checked; a handful of countries show a real, still-unexplained emissions gap in organic_soil, tracked separately as a follow-up rather than blocking this change.
