### PR TITLE
Add livestock lgms

### DIFF
--- a/api/app/domain/analyzers/land_ghg_inventory_analyzer.py
+++ b/api/app/domain/analyzers/land_ghg_inventory_analyzer.py
@@ -46,7 +46,7 @@ INPUT_URIS = {
         ),
         "admin_agriculture_results_uri": (
             "s3://lcl-analytics/zonal-statistics/land_ghg_inventory-agriculture/"
-            "v20260727/admin-land_ghg_inventory-agriculture.parquet"
+            "v20260803/admin-land_ghg_inventory-agriculture.parquet"
         ),
         "admin_mineral_soil_results_uri": (
             "s3://lcl-analytics/zonal-statistics/land_ghg_inventory-mineral_soil/"
@@ -69,7 +69,7 @@ class LandGHGInventoryAnalyzer(Analyzer):
       - "vegetation": gross emissions / removals / net flux / area by
         land_state_class x year.
       - "agriculture": a coarse snapshot of gross emissions by category
-        (cropland) only - no year, removals, net flux, or area.
+        (cropland, livestock) only - no year, removals, net flux, or area.
       - "mineral_soil": gross emissions / removals / net flux / area by
         aoi_id x year (2016-2024). The underlying data is a single static
         snapshot (the 2015-2020 SOC change interval); the same value is

--- a/api/app/domain/analyzers/land_ghg_inventory_analyzer.py
+++ b/api/app/domain/analyzers/land_ghg_inventory_analyzer.py
@@ -25,9 +25,10 @@ MINERAL_SOIL_MEASURES = (
     "area_ha",
 )
 
-# vegetation years soil measures are annualized across (see analyze_mineral_soil,
-# analyze_organic_soil): both soils are modeled at coarser-than-annual resolution
-# (a single change interval, or two 5-year blocks) but are broadcast to match
+# vegetation years agriculture and soil measures are annualized across (see
+# analyze_agriculture, analyze_mineral_soil, analyze_organic_soil): all three
+# are modeled at coarser-than-annual resolution (a single snapshot, a single
+# change interval, or two 5-year blocks) but are broadcast to match
 # vegetation's per-year shape so consumers can treat all components uniformly.
 ANNUALIZED_YEARS = tuple(range(2016, 2025))
 
@@ -68,8 +69,10 @@ class LandGHGInventoryAnalyzer(Analyzer):
     differently:
       - "vegetation": gross emissions / removals / net flux / area by
         land_state_class x year.
-      - "agriculture": a coarse snapshot of gross emissions by category
-        (cropland, livestock) only - no year, removals, net flux, or area.
+      - "agriculture": gross emissions by aoi_id x category (cropland,
+        livestock) x year (2016-2024). The underlying data is a single
+        static snapshot; the same value is broadcast across every year for
+        a vegetation-year-aligned shape. No removals, net flux, or area.
       - "mineral_soil": gross emissions / removals / net flux / area by
         aoi_id x year (2016-2024). The underlying data is a single static
         snapshot (the 2015-2020 SOC change interval); the same value is
@@ -116,7 +119,12 @@ class LandGHGInventoryAnalyzer(Analyzer):
 
     async def analyze_agriculture(self, aoi_ids) -> Dict[str, Any]:
         columns = ("aoi_id", "aoi_type", "category", "gross_emissions_MgCO2e")
-        return await self._select(self.query_services["agriculture"], columns, aoi_ids)
+        result = await self._select(
+            self.query_services["agriculture"], columns, aoi_ids
+        )
+        df = pd.DataFrame(result)
+        df["year"] = [ANNUALIZED_YEARS] * len(df)
+        return df.explode("year", ignore_index=True).to_dict(orient="list")
 
     async def analyze_mineral_soil(self, aoi_ids) -> Dict[str, Any]:
         columns = ("aoi_id", "aoi_type") + MINERAL_SOIL_MEASURES

--- a/api/app/domain/analyzers/land_ghg_inventory_analyzer.py
+++ b/api/app/domain/analyzers/land_ghg_inventory_analyzer.py
@@ -120,7 +120,9 @@ class LandGHGInventoryAnalyzer(Analyzer):
 
     async def analyze_mineral_soil(self, aoi_ids) -> Dict[str, Any]:
         columns = ("aoi_id", "aoi_type") + MINERAL_SOIL_MEASURES
-        result = await self._select(self.query_services["mineral_soil"], columns, aoi_ids)
+        result = await self._select(
+            self.query_services["mineral_soil"], columns, aoi_ids
+        )
         df = pd.DataFrame(result)
         df["year"] = [ANNUALIZED_YEARS] * len(df)
         return df.explode("year", ignore_index=True).to_dict(orient="list")
@@ -133,7 +135,9 @@ class LandGHGInventoryAnalyzer(Analyzer):
             "gross_emissions_MgCO2e",
             "area_ha",
         )
-        result = await self._select(self.query_services["organic_soil"], columns, aoi_ids)
+        result = await self._select(
+            self.query_services["organic_soil"], columns, aoi_ids
+        )
         df = pd.DataFrame(result)
         df["year"] = df["interval_end_year"].map(ORGANIC_SOIL_INTERVAL_YEARS)
         df = df.explode("year", ignore_index=True).drop(columns="interval_end_year")

--- a/api/app/models/land_change/land_ghg_inventory.py
+++ b/api/app/models/land_change/land_ghg_inventory.py
@@ -11,7 +11,7 @@ ANALYTICS_NAME = "land_ghg_inventory"
 
 class LandGHGInventoryAnalyticsIn(AnalyticsIn):
     _analytics_name: str = PrivateAttr(default=ANALYTICS_NAME)
-    _version: str = PrivateAttr(default="v20260731")
+    _version: str = PrivateAttr(default="v20260803")
     aoi: AdminAreaOfInterest = Field(
         ...,
         title="AOI",
@@ -53,10 +53,13 @@ class LandGHGInventoryAnalyticsResponse(Response):
                             },
                             # coarse snapshot: emissions only, by category
                             "agriculture": {
-                                "aoi_id": ["BRA.1"],
-                                "aoi_type": ["admin"],
-                                "category": ["cropland"],
-                                "gross_emissions_MgCO2e": [123234500000.0],
+                                "aoi_id": ["BRA.1", "BRA.1"],
+                                "aoi_type": ["admin", "admin"],
+                                "category": ["cropland", "livestock"],
+                                "gross_emissions_MgCO2e": [
+                                    123234500000.0,
+                                    45123400000.0,
+                                ],
                             },
                             # single static snapshot (2015-2020 SOC change
                             # interval), broadcast across every vegetation

--- a/api/app/models/land_change/land_ghg_inventory.py
+++ b/api/app/models/land_change/land_ghg_inventory.py
@@ -51,13 +51,23 @@ class LandGHGInventoryAnalyticsResponse(Response):
                                 "net_flux_MgCO2e": [409076565.0, -3213337.0],
                                 "area_ha": [1086087.0, 518423.0],
                             },
-                            # coarse snapshot: emissions only, by category
+                            # single static snapshot per category (cropland,
+                            # livestock), broadcast across every vegetation
+                            # year (2016-2024) so the shape matches vegetation
                             "agriculture": {
-                                "aoi_id": ["BRA.1", "BRA.1"],
-                                "aoi_type": ["admin", "admin"],
-                                "category": ["cropland", "livestock"],
+                                "aoi_id": ["BRA.1", "BRA.1", "BRA.1", "BRA.1"],
+                                "aoi_type": ["admin", "admin", "admin", "admin"],
+                                "category": [
+                                    "cropland",
+                                    "cropland",
+                                    "livestock",
+                                    "livestock",
+                                ],
+                                "year": [2016, 2017, 2016, 2017],
                                 "gross_emissions_MgCO2e": [
                                     123234500000.0,
+                                    123234500000.0,
+                                    45123400000.0,
                                     45123400000.0,
                                 ],
                             },

--- a/api/test/integration/test_land_ghg_inventory.py
+++ b/api/test/integration/test_land_ghg_inventory.py
@@ -183,9 +183,11 @@ class TestLandGHGInventoryPostWithNoPreviousRequest:
 
         agriculture = data["result"]["agriculture"]
         assert set(agriculture).issuperset(
-            {"aoi_id", "aoi_type", "category", "gross_emissions_MgCO2e"}
+            {"aoi_id", "aoi_type", "category", "year", "gross_emissions_MgCO2e"}
         )
         assert set(agriculture["category"]) == {"cropland", "livestock"}
+        # the static snapshot is broadcast across every vegetation year, per category
+        assert set(agriculture["year"]) == set(range(2016, 2025))
 
         mineral_soil = data["result"]["mineral_soil"]
         assert set(mineral_soil).issuperset(

--- a/api/test/integration/test_land_ghg_inventory.py
+++ b/api/test/integration/test_land_ghg_inventory.py
@@ -55,10 +55,10 @@ VEGETATION_PAYLOAD = {
 }
 
 AGRICULTURE_PAYLOAD = {
-    "aoi_id": ["BRA.1"],
-    "aoi_type": ["admin"],
-    "category": ["cropland"],
-    "gross_emissions_MgCO2e": [123.0],
+    "aoi_id": ["BRA.1", "BRA.1"],
+    "aoi_type": ["admin", "admin"],
+    "category": ["cropland", "livestock"],
+    "gross_emissions_MgCO2e": [123.0, 45.0],
 }
 
 MINERAL_SOIL_PAYLOAD = {
@@ -185,7 +185,7 @@ class TestLandGHGInventoryPostWithNoPreviousRequest:
         assert set(agriculture).issuperset(
             {"aoi_id", "aoi_type", "category", "gross_emissions_MgCO2e"}
         )
-        assert set(agriculture["category"]) == {"cropland"}
+        assert set(agriculture["category"]) == {"cropland", "livestock"}
 
         mineral_soil = data["result"]["mineral_soil"]
         assert set(mineral_soil).issuperset(

--- a/api/test/unit/domain/analyzers/test_land_ghg_inventory_analyzer.py
+++ b/api/test/unit/domain/analyzers/test_land_ghg_inventory_analyzer.py
@@ -82,10 +82,17 @@ def agriculture_parquet(tmp_path):
     """Agriculture snapshot parquet; carries its own aoi_type (unlike vegetation)."""
     df = pd.DataFrame(
         {
-            "category": ["cropland", "cropland", "cropland"],
-            "gross_emissions_MgCO2e": [10.0, 5.0, 1.0],
-            "aoi_id": ["BRA.1", "COL", "PER"],
-            "aoi_type": ["admin", "admin", "admin"],
+            "category": [
+                "cropland",
+                "cropland",
+                "cropland",
+                "livestock",
+                "livestock",
+                "livestock",
+            ],
+            "gross_emissions_MgCO2e": [10.0, 5.0, 1.0, 8.0, 4.0, 2.0],
+            "aoi_id": ["BRA.1", "COL", "PER", "BRA.1", "COL", "PER"],
+            "aoi_type": ["admin"] * 6,
         }
     )
     parquet_file = tmp_path / "agriculture.parquet"
@@ -215,7 +222,7 @@ async def test_agriculture_query_returns_emissions_by_category(
     assert set(result.columns) == EXPECTED_AGRICULTURE_COLUMNS
     # only the requested admin ids come back (PER filtered out)
     assert set(result.aoi_id) == {"BRA.1", "COL"}
-    assert set(result.category) == {"cropland"}
+    assert set(result.category) == {"cropland", "livestock"}
     assert set(result.aoi_type) == {"admin"}
 
 

--- a/api/test/unit/domain/analyzers/test_land_ghg_inventory_analyzer.py
+++ b/api/test/unit/domain/analyzers/test_land_ghg_inventory_analyzer.py
@@ -29,11 +29,12 @@ EXPECTED_VEGETATION_COLUMNS = {
     "area_ha",
 }
 
-# agriculture is a coarse snapshot: emissions only, by category, no year/area/removals
+# agriculture's static snapshot is broadcast to a year per row (2016-2024)
 EXPECTED_AGRICULTURE_COLUMNS = {
     "aoi_id",
     "aoi_type",
     "category",
+    "year",
     "gross_emissions_MgCO2e",
 }
 
@@ -203,7 +204,7 @@ async def test_vegetation_query_returns_flux_by_land_state_and_year(
 
 
 @pytest.mark.asyncio
-async def test_agriculture_query_returns_emissions_by_category(
+async def test_agriculture_query_broadcasts_snapshot_to_years(
     vegetation_parquet, agriculture_parquet, mineral_soil_parquet, organic_soil_parquet
 ):
     analytics_in = LandGHGInventoryAnalyticsIn(
@@ -224,6 +225,15 @@ async def test_agriculture_query_returns_emissions_by_category(
     assert set(result.aoi_id) == {"BRA.1", "COL"}
     assert set(result.category) == {"cropland", "livestock"}
     assert set(result.aoi_type) == {"admin"}
+    # the static snapshot is broadcast across every vegetation year, per category
+    bra_cropland = result[(result.aoi_id == "BRA.1") & (result.category == "cropland")]
+    assert set(bra_cropland.year) == set(range(2016, 2025))
+    assert (bra_cropland.gross_emissions_MgCO2e == 10.0).all()
+    bra_livestock = result[
+        (result.aoi_id == "BRA.1") & (result.category == "livestock")
+    ]
+    assert set(bra_livestock.year) == set(range(2016, 2025))
+    assert (bra_livestock.gross_emissions_MgCO2e == 8.0).all()
 
 
 @pytest.mark.asyncio

--- a/pipelines/globals.py
+++ b/pipelines/globals.py
@@ -44,11 +44,20 @@ land_ghg_inventory_organic_soil_zarr_uri = (
     "mega_zarr/ogh_mixed_f1_f15_f2_20260513/five_year/4000_pixels/20260525/mega.zarr"
 )
 # Agriculture emissions (cropland + livestock). Single static snapshot, no year
-# axis. Source COGs are per-hectare (kg/ha); this zarr stores the converted
-# per-pixel absolute totals (Mg). group="pipeline".
+# axis. Livestock's source COG is per-hectare (kg/ha); cropland's is an
+# absolute per-pixel total (kg), mass-conserving-resampled -- see
+# create_agriculture_zarr.py. This zarr stores the converted per-pixel
+# absolute totals (Mg). group="pipeline".
+#
+# v2: cropland switched from area-weighting a per-hectare rate (which
+# overstated totals ~5.3x against an independent QC reference, since the
+# rate's area denominator was physical cropland area, not full pixel area)
+# to the mass-conserving uniform-split resample of the absolute total COG.
+# Kept as a new sibling path rather than overwriting the original so the old
+# zarr stays available until the new one is QC'd.
 land_ghg_inventory_agriculture_zarr_uri = (
     f"s3://{ANALYTICS_BUCKET}/zarr/land-ghg-monitoring-system/"
-    "cropland_livestock_emissions.zarr"
+    "cropland_livestock_emissions_v2.zarr"
 )
 
 grasslands_zarr_uri = f"s3://{ANALYTICS_BUCKET}/zarr/grasslands/v1/grasslands.zarr"

--- a/pipelines/globals.py
+++ b/pipelines/globals.py
@@ -44,9 +44,8 @@ land_ghg_inventory_organic_soil_zarr_uri = (
     "mega_zarr/ogh_mixed_f1_f15_f2_20260513/five_year/4000_pixels/20260525/mega.zarr"
 )
 # Agriculture emissions (cropland + livestock). Single static snapshot, no year
-# axis; per-pixel absolute totals (not per-hectare). group="pipeline".
-# Agriculture emissions (cropland). Single static snapshot, no year axis;
-# per-pixel absolute totals (not per-hectare). group="pipeline".
+# axis. Source COGs are per-hectare (kg/ha); this zarr stores the converted
+# per-pixel absolute totals (Mg). group="pipeline".
 land_ghg_inventory_agriculture_zarr_uri = (
     f"s3://{ANALYTICS_BUCKET}/zarr/land-ghg-monitoring-system/"
     "cropland_livestock_emissions.zarr"

--- a/pipelines/land_ghg_inventory/agriculture_stages.py
+++ b/pipelines/land_ghg_inventory/agriculture_stages.py
@@ -1,15 +1,15 @@
 """Zonal-statistics stages for Land GHG inventory agriculture emissions.
 
-Sums already-absolute per-pixel cropland emissions grouped by admin unit x
-category (cropland) only (no land_state_class, no year — a single static
-snapshot), then rolls up to aoi_id. The reduce and GADM roll-up are reused from
-``pipelines.prefect_flows.common_stages``.
+Sums already-absolute per-pixel cropland and livestock emissions grouped by
+admin unit x category (cropland, livestock) only (no land_state_class, no
+year — a single static snapshot), then rolls up to aoi_id. The reduce and GADM
+roll-up are reused from ``pipelines.prefect_flows.common_stages``.
 
 Output parquet schema (one row per aoi_id x category)::
 
     aoi_id                    str    admin unit, e.g. "BRA", "BRA.1", "BRA.1.1"
     aoi_type                  str    always "admin"
-    category                  str    "cropland"
+    category                  str    "cropland" or "livestock"
     gross_emissions_MgCO2e    float  summed emissions for aoi_id x category
 """
 
@@ -32,6 +32,7 @@ from shapely.geometry import Polygon
 # canonical category -> source variable in the agriculture zarr
 AGRICULTURE_SOURCE_VARS = {
     "cropland": "cropland_emissions",
+    "livestock": "livestock_emissions",
 }
 AGRICULTURE_ZARR_GROUP = "pipeline"
 
@@ -43,8 +44,9 @@ def load_agriculture(
     subregion_uri: str,
     bbox: Optional[Polygon] = None,
 ) -> Tuple[xr.Dataset, xr.DataArray, xr.DataArray, xr.DataArray]:
-    """Load the agriculture emissions (already per-pixel absolute totals, no year
-    axis) and GADM layers, aligned to the agriculture grid."""
+    """Load the agriculture emissions (cropland + livestock, already per-pixel
+    absolute totals, no year axis) and GADM layers, aligned to the agriculture
+    grid."""
     ag = _load_zarr(agriculture_uri, group=AGRICULTURE_ZARR_GROUP)[
         list(AGRICULTURE_SOURCE_VARS.values())
     ]
@@ -63,8 +65,8 @@ def load_agriculture(
 def setup_agriculture_compute(datasets: Tuple, expected_groups: Tuple) -> Tuple:
     """Build the agriculture measure cube + admin group-by layers for the reduce.
 
-    Stacks the per-pixel absolute cropland totals into a ``category``
-    dim; grouping is admin-only (country x region x subregion).
+    Stacks the per-pixel absolute cropland and livestock totals into a
+    ``category`` dim; grouping is admin-only (country x region x subregion).
     """
     ag, country, region, subregion = datasets
     cube = ag.fillna(0).astype("float64").to_dataarray(dim="category")
@@ -79,8 +81,9 @@ def setup_agriculture_compute(datasets: Tuple, expected_groups: Tuple) -> Tuple:
 def agriculture_result_dataframe(reduced: xr.DataArray) -> pd.DataFrame:
     """Reshape the sparse agriculture reduce into tidy aoi_id x category rows.
 
-    Cropland emissions stay as their own row (one per admin unit x category)
-    rather than a column, so consumers group/filter by ``category``.
+    Cropland and livestock emissions each stay as their own row (one per admin
+    unit x category) rather than a column, so consumers group/filter by
+    ``category``.
     """
     df = common_create_result_dataframe(reduced)
     df = df.rename(columns={"value": "gross_emissions_MgCO2e"})

--- a/pipelines/land_ghg_inventory/create_agriculture_zarr.py
+++ b/pipelines/land_ghg_inventory/create_agriculture_zarr.py
@@ -1,12 +1,12 @@
 """Builds the agriculture emissions zarr consumed by ``agriculture_stages``.
 
-Cropland emissions are published as a global COG on its own native grid (~10km,
-WGS84), carrying a per-hectare rate in kg/ha. This resamples it onto the
-vegetation zarr's 30m grid (the reference grid for the whole Land GHG inventory)
-via ``odc.geo``'s dask-parallel nearest-neighbor reprojection, multiplies by the
-UMD pixel-area zarr (already on the 30m grid, snapped on via
-``common.align_to``) to recover an absolute per-pixel total, converts kg -> Mg,
-and writes a single-variable zarr matching
+Cropland and livestock emissions are each published as a global COG on their
+own native grid (~10km, WGS84), carrying a per-hectare rate in kg/ha. This
+resamples each onto the vegetation zarr's 30m grid (the reference grid for the
+whole Land GHG inventory) via ``odc.geo``'s dask-parallel nearest-neighbor
+reprojection, multiplies by the UMD pixel-area zarr (already on the 30m grid,
+snapped on via ``common.align_to``) to recover an absolute per-pixel total,
+converts kg -> Mg, and writes a two-variable zarr matching
 ``agriculture_stages.AGRICULTURE_SOURCE_VARS``.
 """
 
@@ -30,13 +30,18 @@ from pipelines.utils import s3_uri_exists
 # only its geobox (30m, EPSG:4326) is used, not its values.
 REFERENCE_GRID_VAR = "gross_emissions__all_C_pools__all_gases__MgCO2e_ha_yr"
 
-# Source COG: a static snapshot (single year, no versioning scheme), published by
-# Cornell. Per-hectare rate in kg/ha.
+# Source COGs: static snapshots (single year, no versioning scheme), published
+# by Cornell. Per-hectare rate in kg/ha.
 CROPLAND_COG_URI = (
     "s3://gfw2-data/climate/AFOLU_flux_model/cropland_emissions/processed/"
     "Cornell_v20250828/year_2020/global_COG/all_sources/"
     "Global_grid_all_GHGs_cropland_mean_rate_physical_area_CO2eq_all_crops_"
     "NonPeatland_2019_kg_ha_CO2_COG.tif"
+)
+LIVESTOCK_COG_URI = (
+    "s3://gfw2-data/climate/AFOLU_flux_model/livestock_emissions/"
+    "raw__from_Cornell/20260731_emis_per_ha_only/Total_GHG_Emissions/"
+    "Tot_CO2eq_kg_livestock_GHG_emissions_kgCO2e_ha.tif"
 )
 KG_PER_MG = 1_000
 
@@ -70,9 +75,9 @@ def _resample(cog_uri: str, geobox) -> xr.DataArray:
 
 
 def create_agriculture_zarr(overwrite: bool = False) -> str:
-    """Resample cropland emissions onto the vegetation grid, convert per-hectare
-    rates to absolute per-pixel Mg totals, and write the zarr consumed by
-    ``agriculture_stages.load_agriculture``."""
+    """Resample cropland and livestock emissions onto the vegetation grid,
+    convert per-hectare rates to absolute per-pixel Mg totals, and write the
+    zarr consumed by ``agriculture_stages.load_agriculture``."""
     marker_uri = (
         f"{land_ghg_inventory_agriculture_zarr_uri}/{AGRICULTURE_ZARR_GROUP}/zarr.json"
     )
@@ -80,11 +85,21 @@ def create_agriculture_zarr(overwrite: bool = False) -> str:
         return land_ghg_inventory_agriculture_zarr_uri
 
     geobox = _reference_geobox()
-    cropland_kg_ha = _resample(CROPLAND_COG_URI, geobox)
-    pixel_area_ha = align_to(cropland_kg_ha, pixel_area_zarr_uri)
-    cropland = (cropland_kg_ha * pixel_area_ha) / KG_PER_MG
 
-    combined = xr.Dataset({AGRICULTURE_SOURCE_VARS["cropland"]: cropland})
+    cropland_kg_ha = _resample(CROPLAND_COG_URI, geobox)
+    cropland_pixel_area_ha = align_to(cropland_kg_ha, pixel_area_zarr_uri)
+    cropland = (cropland_kg_ha * cropland_pixel_area_ha) / KG_PER_MG
+
+    livestock_kg_ha = _resample(LIVESTOCK_COG_URI, geobox)
+    livestock_pixel_area_ha = align_to(livestock_kg_ha, pixel_area_zarr_uri)
+    livestock = (livestock_kg_ha * livestock_pixel_area_ha) / KG_PER_MG
+
+    combined = xr.Dataset(
+        {
+            AGRICULTURE_SOURCE_VARS["cropland"]: cropland,
+            AGRICULTURE_SOURCE_VARS["livestock"]: livestock,
+        }
+    )
     combined.to_zarr(
         land_ghg_inventory_agriculture_zarr_uri, group=AGRICULTURE_ZARR_GROUP, mode="w"
     )

--- a/pipelines/land_ghg_inventory/create_agriculture_zarr.py
+++ b/pipelines/land_ghg_inventory/create_agriculture_zarr.py
@@ -34,10 +34,10 @@ REFERENCE_GRID_VAR = "gross_emissions__all_C_pools__all_gases__MgCO2e_ha_yr"
 # Source COGs: static snapshots (single year, no versioning scheme), published
 # by Cornell. Per-hectare rate in kg/ha.
 CROPLAND_COG_URI = (
-    "s3://gfw2-data/climate/AFOLU_flux_model/cropland_emissions/processed/"
-    "Cornell_v20250828/year_2020/global_COG/all_sources/"
-    "Global_grid_all_GHGs_cropland_mean_rate_physical_area_CO2eq_all_crops_"
-    "NonPeatland_2019_kg_ha_CO2_COG.tif"
+    "s3://gfw2-data/climate/AFOLU_flux_model/cropland_emissions/"
+    "raw__from_Cornell/20250828/year_2020/all_sources/"
+    "Global_grid_cropland_emissions_mean_rate_physical_area_CO2eq_all_crops_"
+    "without_peat_burn_kg_ha_CO2__20260803.tif"
 )
 LIVESTOCK_COG_URI = (
     "s3://gfw2-data/climate/AFOLU_flux_model/livestock_emissions/"

--- a/pipelines/land_ghg_inventory/create_agriculture_zarr.py
+++ b/pipelines/land_ghg_inventory/create_agriculture_zarr.py
@@ -14,6 +14,7 @@ import rasterio
 import rioxarray as rio
 import xarray as xr
 from odc.geo.xr import xr_reproject
+
 from pipelines.globals import (
     land_ghg_inventory_agriculture_zarr_uri,
     land_ghg_inventory_vegetation_zarr_uri,
@@ -87,12 +88,13 @@ def create_agriculture_zarr(overwrite: bool = False) -> str:
     geobox = _reference_geobox()
 
     cropland_kg_ha = _resample(CROPLAND_COG_URI, geobox)
-    cropland_pixel_area_ha = align_to(cropland_kg_ha, pixel_area_zarr_uri)
-    cropland = (cropland_kg_ha * cropland_pixel_area_ha) / KG_PER_MG
-
     livestock_kg_ha = _resample(LIVESTOCK_COG_URI, geobox)
-    livestock_pixel_area_ha = align_to(livestock_kg_ha, pixel_area_zarr_uri)
-    livestock = (livestock_kg_ha * livestock_pixel_area_ha) / KG_PER_MG
+    # both are already reprojected onto the same geobox, so pixel area only
+    # needs aligning once and can be reused for both conversions.
+    pixel_area_ha = align_to(cropland_kg_ha, pixel_area_zarr_uri)
+
+    cropland = (cropland_kg_ha * pixel_area_ha) / KG_PER_MG
+    livestock = (livestock_kg_ha * pixel_area_ha) / KG_PER_MG
 
     combined = xr.Dataset(
         {

--- a/pipelines/land_ghg_inventory/create_agriculture_zarr.py
+++ b/pipelines/land_ghg_inventory/create_agriculture_zarr.py
@@ -1,15 +1,30 @@
 """Builds the agriculture emissions zarr consumed by ``agriculture_stages``.
 
-Cropland and livestock emissions are each published as a global COG on their
-own native grid (~10km, WGS84), carrying a per-hectare rate in kg/ha. This
-resamples each onto the vegetation zarr's 30m grid (the reference grid for the
-whole Land GHG inventory) via ``odc.geo``'s dask-parallel nearest-neighbor
-reprojection, multiplies by the UMD pixel-area zarr (already on the 30m grid,
-snapped on via ``common.align_to``) to recover an absolute per-pixel total,
-converts kg -> Mg, and writes a two-variable zarr matching
-``agriculture_stages.AGRICULTURE_SOURCE_VARS``.
+Livestock emissions are published as a global COG on their native grid
+(~10km, WGS84), carrying a per-hectare rate in kg/ha. This resamples it onto
+the vegetation zarr's 30m grid (the reference grid for the whole Land GHG
+inventory) via ``odc.geo``'s dask-parallel nearest-neighbor reprojection,
+multiplies by the UMD pixel-area zarr (already on the 30m grid, snapped on via
+``common.align_to``) to recover an absolute per-pixel total, converts kg ->
+Mg, and writes it into the agriculture zarr alongside cropland.
+
+Cropland emissions use a different source and resampling strategy. Cornell's
+per-hectare cropland rate (``mean_rate_physical_area``) is normalized by the
+physical cropland area within each pixel (e.g. SPAM2020), not by the pixel's
+full geographic area -- so multiplying that rate by the UMD pixel-area zarr
+(full pixel area) overstates absolute totals wherever a pixel isn't 100%
+cropland, which is almost everywhere (QC against an independent country-level
+reference table showed pipeline totals ~5.3x too high). Cornell also
+publishes the same data as an already-absolute ``total_amount`` COG (kg CO2e
+per ~10km pixel, no area normalization). This is used instead: each parent
+pixel's total is split evenly across however many 30m reference-grid pixels
+fall inside it (a mass-conserving nearest-neighbor downscale, via
+``_resample_total_uniformly``), so the sum over children exactly reproduces
+the parent's original total rather than replicating it.
 """
 
+import dask.array as da
+import numpy as np
 import rasterio
 import rioxarray as rio
 import xarray as xr
@@ -32,12 +47,13 @@ from pipelines.utils import s3_uri_exists
 REFERENCE_GRID_VAR = "gross_emissions__all_C_pools__all_gases__MgCO2e_ha_yr"
 
 # Source COGs: static snapshots (single year, no versioning scheme), published
-# by Cornell. Per-hectare rate in kg/ha.
+# by Cornell. Cropland is the absolute per-pixel total (kg CO2e); livestock is
+# a per-hectare rate (kg/ha).
 CROPLAND_COG_URI = (
     "s3://gfw2-data/climate/AFOLU_flux_model/cropland_emissions/"
     "raw__from_Cornell/20250828/year_2020/all_sources/"
-    "Global_grid_cropland_emissions_mean_rate_physical_area_CO2eq_all_crops_"
-    "without_peat_burn_kg_ha_CO2__20260803.tif"
+    "Global_grid_cropland_emissions_total_amount_CO2eq_all_crops_"
+    "without_peat_burn_kg_CO2__20260803.tif"
 )
 LIVESTOCK_COG_URI = (
     "s3://gfw2-data/climate/AFOLU_flux_model/livestock_emissions/"
@@ -75,10 +91,77 @@ def _resample(cog_uri: str, geobox) -> xr.DataArray:
     return reprojected
 
 
+def _resample_total_uniformly(cog_uri: str, geobox) -> xr.DataArray:
+    """Downscale an absolute per-pixel total COG onto ``geobox``, splitting each
+    source pixel's total evenly across however many destination pixels a
+    nearest-neighbor reprojection maps onto it.
+
+    Plain nearest-neighbor resampling (as ``_resample`` does) replicates a
+    source pixel's value into every destination pixel that maps to it, which
+    is only mass-conserving for rates (kg/ha), not for absolute totals (kg) --
+    replicating an absolute total would multiply it by the number of
+    destination pixels instead of splitting it among them.
+
+    To get an exact per-source-pixel child count that's guaranteed to match
+    what ``xr_reproject`` actually does (rather than reimplementing its
+    nearest-neighbor + bounds-clipping rules independently, which is easy to
+    get subtly wrong at edge/boundary pixels), this reprojects the source
+    pixels' own linear index onto ``geobox`` with the same call used for the
+    value, then counts how many destination pixels each source index actually
+    landed on. Dividing the source total by that count before a second,
+    ordinary nearest-neighbor reprojection makes the replication
+    mass-conserving: summing a source pixel's children reproduces its
+    original total.
+    """
+    with rasterio.Env(AWS_REQUEST_PAYER="requester"):
+        src = rio.open_rasterio(cog_uri, chunks={"x": 10000, "y": 10000})
+    if "band" in src.dims:
+        src = src.isel(band=0, drop=True)
+
+    # out-of-bounds destination pixels get index ``src.size`` (an extra,
+    # discarded bin) instead of a sentinel like -1, so bincount/take need no
+    # boolean masking -- awkward on dask arrays with unknown chunk sizes.
+    src_index = xr.DataArray(
+        np.arange(src.size, dtype="int64").reshape(src.shape),
+        dims=src.dims,
+        coords={"y": src["y"], "x": src["x"]},
+    )
+    src_index.rio.write_crs(src.rio.crs, inplace=True)
+    reprojected_index = xr_reproject(
+        src_index,
+        geobox,
+        resampling="nearest",
+        dst_nodata=src.size,
+        chunks=(10000, 10000),
+        always_yx=True,
+    )
+    if "band" in reprojected_index.dims:
+        reprojected_index = reprojected_index.isel(band=0, drop=True)
+
+    flat_index = reprojected_index.data.ravel()
+    child_counts = da.bincount(flat_index, minlength=src.size + 1)[:-1]
+    per_dst_count = da.where(
+        flat_index < src.size, child_counts[da.minimum(flat_index, src.size - 1)], 1
+    ).reshape(reprojected_index.shape)
+
+    reprojected_value = xr_reproject(
+        src,
+        geobox,
+        resampling="nearest",
+        dst_nodata=0,
+        chunks=(10000, 10000),
+        always_yx=True,
+    )
+    if "band" in reprojected_value.dims:
+        reprojected_value = reprojected_value.isel(band=0, drop=True)
+
+    return reprojected_value.copy(data=reprojected_value.data / per_dst_count)
+
+
 def create_agriculture_zarr(overwrite: bool = False) -> str:
     """Resample cropland and livestock emissions onto the vegetation grid,
-    convert per-hectare rates to absolute per-pixel Mg totals, and write the
-    zarr consumed by ``agriculture_stages.load_agriculture``."""
+    convert to absolute per-pixel Mg totals, and write the zarr consumed by
+    ``agriculture_stages.load_agriculture``."""
     marker_uri = (
         f"{land_ghg_inventory_agriculture_zarr_uri}/{AGRICULTURE_ZARR_GROUP}/zarr.json"
     )
@@ -87,13 +170,13 @@ def create_agriculture_zarr(overwrite: bool = False) -> str:
 
     geobox = _reference_geobox()
 
-    cropland_kg_ha = _resample(CROPLAND_COG_URI, geobox)
+    # cropland is already an absolute per-pixel total (kg); split each source
+    # pixel's total evenly across its 30m children rather than area-weighting.
+    cropland_kg = _resample_total_uniformly(CROPLAND_COG_URI, geobox)
     livestock_kg_ha = _resample(LIVESTOCK_COG_URI, geobox)
-    # both are already reprojected onto the same geobox, so pixel area only
-    # needs aligning once and can be reused for both conversions.
-    pixel_area_ha = align_to(cropland_kg_ha, pixel_area_zarr_uri)
+    pixel_area_ha = align_to(livestock_kg_ha, pixel_area_zarr_uri)
 
-    cropland = (cropland_kg_ha * pixel_area_ha) / KG_PER_MG
+    cropland = cropland_kg / KG_PER_MG
     livestock = (livestock_kg_ha * pixel_area_ha) / KG_PER_MG
 
     combined = xr.Dataset(

--- a/pipelines/land_ghg_inventory/create_agriculture_zarr.py
+++ b/pipelines/land_ghg_inventory/create_agriculture_zarr.py
@@ -150,9 +150,16 @@ def _resample_total_uniformly(cog_uri: str, geobox) -> xr.DataArray:
 
     flat_index = reprojected_index.data.ravel()
     child_counts = da.bincount(flat_index, minlength=src.size + 1)[:-1]
-    per_dst_count = da.where(
-        flat_index < src.size, child_counts[da.minimum(flat_index, src.size - 1)], 1
-    ).reshape(reprojected_index.shape)
+    # ravel/reshape doesn't preserve reprojected_index's original 2D block
+    # chunking (it comes out re-chunked along a flattened layout instead);
+    # rechunk back to match, since a mismatched chunking here against
+    # reprojected_value below fails at zarr-write time ("Zarr requires
+    # uniform chunk sizes").
+    per_dst_count = (
+        da.where(flat_index < src.size, child_counts[da.minimum(flat_index, src.size - 1)], 1)
+        .reshape(reprojected_index.shape)
+        .rechunk(reprojected_index.data.chunks)
+    )
 
     reprojected_value = xr_reproject(
         src,

--- a/pipelines/land_ghg_inventory/create_agriculture_zarr.py
+++ b/pipelines/land_ghg_inventory/create_agriculture_zarr.py
@@ -121,8 +121,18 @@ def _resample_total_uniformly(cog_uri: str, geobox) -> xr.DataArray:
     # out-of-bounds destination pixels get index ``src.size`` (an extra,
     # discarded bin) instead of a sentinel like -1, so bincount/take need no
     # boolean masking -- awkward on dask arrays with unknown chunk sizes.
+    #
+    # Built as a dask array (matching src's own chunking) rather than a plain
+    # numpy array: xr_reproject only dask-parallelizes a dask-backed input --
+    # given a numpy array it allocates the full (non-chunked) destination
+    # array eagerly, which at the real ~720000x1440000 reference grid tried
+    # to allocate 7.5 TiB and OOM'd. src itself is small (~10km resolution),
+    # so building the index eagerly in numpy and rechunking it is cheap.
     src_index = xr.DataArray(
-        np.arange(src.size, dtype="int64").reshape(src.shape),
+        da.from_array(
+            np.arange(src.size, dtype="int64").reshape(src.shape),
+            chunks=src.data.chunks,
+        ),
         dims=src.dims,
         coords={"y": src["y"], "x": src["x"]},
     )

--- a/pipelines/land_ghg_inventory/create_agriculture_zarr.py
+++ b/pipelines/land_ghg_inventory/create_agriculture_zarr.py
@@ -17,14 +17,13 @@ cropland, which is almost everywhere (QC against an independent country-level
 reference table showed pipeline totals ~5.3x too high). Cornell also
 publishes the same data as an already-absolute ``total_amount`` COG (kg CO2e
 per ~10km pixel, no area normalization). This is used instead: each parent
-pixel's total is split evenly across however many 30m reference-grid pixels
-fall inside it (a mass-conserving nearest-neighbor downscale, via
-``_resample_total_uniformly``), so the sum over children exactly reproduces
-the parent's original total rather than replicating it.
+pixel's total is divided by its (unrounded) number of 30m reference-grid
+children before an ordinary nearest-neighbor reprojection (``_resample_total_uniformly``),
+so replication approximately splits rather than multiplies each parent's
+total -- exact for no single pixel (the real child count alternates by +/-1
+around the average), but unbiased in aggregate.
 """
 
-import dask.array as da
-import numpy as np
 import rasterio
 import rioxarray as rio
 import xarray as xr
@@ -92,9 +91,8 @@ def _resample(cog_uri: str, geobox) -> xr.DataArray:
 
 
 def _resample_total_uniformly(cog_uri: str, geobox) -> xr.DataArray:
-    """Downscale an absolute per-pixel total COG onto ``geobox``, splitting each
-    source pixel's total evenly across however many destination pixels a
-    nearest-neighbor reprojection maps onto it.
+    """Downscale an absolute per-pixel total COG onto ``geobox`` by splitting
+    each source pixel's total evenly across its destination children.
 
     Plain nearest-neighbor resampling (as ``_resample`` does) replicates a
     source pixel's value into every destination pixel that maps to it, which
@@ -102,77 +100,37 @@ def _resample_total_uniformly(cog_uri: str, geobox) -> xr.DataArray:
     replicating an absolute total would multiply it by the number of
     destination pixels instead of splitting it among them.
 
-    To get an exact per-source-pixel child count that's guaranteed to match
-    what ``xr_reproject`` actually does (rather than reimplementing its
-    nearest-neighbor + bounds-clipping rules independently, which is easy to
-    get subtly wrong at edge/boundary pixels), this reprojects the source
-    pixels' own linear index onto ``geobox`` with the same call used for the
-    value, then counts how many destination pixels each source index actually
-    landed on. Dividing the source total by that count before a second,
-    ordinary nearest-neighbor reprojection makes the replication
-    mass-conserving: summing a source pixel's children reproduces its
-    original total.
+    The true child count per source pixel alternates by +/-1 around
+    ``(src_res / dst_res) ** 2`` (e.g. 333 or 334 here, since 0.08333.../0.00025
+    isn't an integer ratio) depending on where a given source pixel happens to
+    land relative to the destination grid. Rather than computing that exact,
+    varying count, this divides by the unrounded ratio everywhere -- a single
+    global constant. Any one source pixel's children then sum to only
+    approximately (not exactly) its original total, off by however far its
+    actual child count deviates from the mean ratio (~0.3% here in the
+    worst case); summed over the whole raster this has no systematic
+    direction, so the aggregate (e.g. a country total) is unaffected.
     """
     with rasterio.Env(AWS_REQUEST_PAYER="requester"):
         src = rio.open_rasterio(cog_uri, chunks={"x": 10000, "y": 10000})
     if "band" in src.dims:
         src = src.isel(band=0, drop=True)
 
-    # out-of-bounds destination pixels get index ``src.size`` (an extra,
-    # discarded bin) instead of a sentinel like -1, so bincount/take need no
-    # boolean masking -- awkward on dask arrays with unknown chunk sizes.
-    #
-    # Built as a dask array (matching src's own chunking) rather than a plain
-    # numpy array: xr_reproject only dask-parallelizes a dask-backed input --
-    # given a numpy array it allocates the full (non-chunked) destination
-    # array eagerly, which at the real ~720000x1440000 reference grid tried
-    # to allocate 7.5 TiB and OOM'd. src itself is small (~10km resolution),
-    # so building the index eagerly in numpy and rechunking it is cheap.
-    src_index = xr.DataArray(
-        da.from_array(
-            np.arange(src.size, dtype="int64").reshape(src.shape),
-            chunks=src.data.chunks,
-        ),
-        dims=src.dims,
-        coords={"y": src["y"], "x": src["x"]},
-    )
-    src_index.rio.write_crs(src.rio.crs, inplace=True)
-    reprojected_index = xr_reproject(
-        src_index,
-        geobox,
-        resampling="nearest",
-        dst_nodata=src.size,
-        chunks=(10000, 10000),
-        always_yx=True,
-    )
-    if "band" in reprojected_index.dims:
-        reprojected_index = reprojected_index.isel(band=0, drop=True)
+    children_per_row = abs(src.rio.resolution()[1]) / abs(geobox.resolution.y)
+    children_per_col = abs(src.rio.resolution()[0]) / abs(geobox.resolution.x)
+    per_child_value = src / (children_per_row * children_per_col)
 
-    flat_index = reprojected_index.data.ravel()
-    child_counts = da.bincount(flat_index, minlength=src.size + 1)[:-1]
-    # ravel/reshape doesn't preserve reprojected_index's original 2D block
-    # chunking (it comes out re-chunked along a flattened layout instead);
-    # rechunk back to match, since a mismatched chunking here against
-    # reprojected_value below fails at zarr-write time ("Zarr requires
-    # uniform chunk sizes").
-    per_dst_count = (
-        da.where(flat_index < src.size, child_counts[da.minimum(flat_index, src.size - 1)], 1)
-        .reshape(reprojected_index.shape)
-        .rechunk(reprojected_index.data.chunks)
-    )
-
-    reprojected_value = xr_reproject(
-        src,
+    reprojected = xr_reproject(
+        per_child_value,
         geobox,
         resampling="nearest",
         dst_nodata=0,
         chunks=(10000, 10000),
         always_yx=True,
     )
-    if "band" in reprojected_value.dims:
-        reprojected_value = reprojected_value.isel(band=0, drop=True)
-
-    return reprojected_value.copy(data=reprojected_value.data / per_dst_count)
+    if "band" in reprojected.dims:
+        reprojected = reprojected.isel(band=0, drop=True)
+    return reprojected
 
 
 def create_agriculture_zarr(overwrite: bool = False) -> str:

--- a/pipelines/land_ghg_inventory/prefect_flows/land_ghg_inventory_flow.py
+++ b/pipelines/land_ghg_inventory/prefect_flows/land_ghg_inventory_flow.py
@@ -89,9 +89,9 @@ def land_ghg_inventory_agriculture(
     overwrite: bool = False,
     bbox: Optional[Polygon] = None,
 ) -> str:
-    """Land GHG inventory agriculture zonal stats: cropland emissions, admin-only
-    (no land_state_class, no year axis -- a single static snapshot), rolled up to
-    aoi_id.
+    """Land GHG inventory agriculture zonal stats: cropland and livestock
+    emissions, admin-only (no land_state_class, no year axis -- a single
+    static snapshot), rolled up to aoi_id.
 
     ``bbox`` clips the reduce to one area for a laptop-friendly local run; the
     result is written to a local parquet

--- a/pipelines/test/integration/land_ghg_inventory/test_agriculture_flow.py
+++ b/pipelines/test/integration/land_ghg_inventory/test_agriculture_flow.py
@@ -27,7 +27,7 @@ STP_BBOX = box(6.4, -0.05, 7.5, 1.8)
 # the full gadm_*_code_count admin codes changes these, since STP's own codes are
 # within range).
 EXPECTED_TOTALS = {
-    "cropland": 1.7105374e04,
+    "cropland": 1.7466945e03,
     "livestock": 1.2441838e04,
 }
 

--- a/pipelines/test/integration/land_ghg_inventory/test_agriculture_flow.py
+++ b/pipelines/test/integration/land_ghg_inventory/test_agriculture_flow.py
@@ -28,6 +28,7 @@ STP_BBOX = box(6.4, -0.05, 7.5, 1.8)
 # within range).
 EXPECTED_TOTALS = {
     "cropland": 1.7105374e04,
+    "livestock": 1.2441838e04,
 }
 
 
@@ -54,3 +55,4 @@ def test_stp_reproduces_reference_totals():
     assert not country.empty
     totals = country.groupby("category")["gross_emissions_MgCO2e"].sum()
     assert totals["cropland"] == pytest.approx(EXPECTED_TOTALS["cropland"], rel=0.02)
+    assert totals["livestock"] == pytest.approx(EXPECTED_TOTALS["livestock"], rel=0.02)

--- a/pipelines/test/unit/land_ghg_inventory/conftest.py
+++ b/pipelines/test/unit/land_ghg_inventory/conftest.py
@@ -71,7 +71,7 @@ def synthetic_agriculture_datasets():
 
     Agriculture values are already per-pixel absolute totals (no pixel-area
     multiplication, no year/land_state axis). Per-pixel totals are known:
-    cropland=[[10, 20], [30, 0]].
+    cropland=[[10, 20], [30, 0]], livestock=[[5, 0], [15, 0]].
     """
     coords2 = {"y": [0.0, 1.0], "x": [0.0, 1.0]}
 
@@ -85,6 +85,7 @@ def synthetic_agriculture_datasets():
     ag = xr.Dataset(
         {
             "cropland": layer([[10.0, 20.0], [30.0, 0.0]]),
+            "livestock": layer([[5.0, 0.0], [15.0, 0.0]]),
         }
     )
 

--- a/pipelines/test/unit/land_ghg_inventory/test_agriculture_result_dataframe.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_agriculture_result_dataframe.py
@@ -5,8 +5,8 @@ from pipelines.prefect_flows import common_stages
 def test_agriculture_result_dataframe_rolls_up(synthetic_agriculture_datasets):
     datasets, expected_groups = synthetic_agriculture_datasets
 
-    cube, groupbys, out_expected_groups = (
-        agriculture_stages.setup_agriculture_compute(datasets, expected_groups)
+    cube, groupbys, out_expected_groups = agriculture_stages.setup_agriculture_compute(
+        datasets, expected_groups
     )
     reduced = common_stages.compute(cube, groupbys, out_expected_groups, "sum")
     df = agriculture_stages.agriculture_result_dataframe(reduced)
@@ -24,23 +24,15 @@ def test_agriculture_result_dataframe_rolls_up(synthetic_agriculture_datasets):
     # subregion-level totals: top row pixels (10+20 cropland, 5+0 livestock),
     # one row per category
     subregion_rows = df[df.aoi_id == "BRA.1.1"]
-    cropland_row = subregion_rows[
-        subregion_rows.category == "cropland"
-    ].iloc[0]
+    cropland_row = subregion_rows[subregion_rows.category == "cropland"].iloc[0]
     assert cropland_row.gross_emissions_MgCO2e == 30.0
-    livestock_row = subregion_rows[
-        subregion_rows.category == "livestock"
-    ].iloc[0]
+    livestock_row = subregion_rows[subregion_rows.category == "livestock"].iloc[0]
     assert livestock_row.gross_emissions_MgCO2e == 5.0
 
     # country-level roll-up: subregion + region-only bottom-left pixel
     # cropland: 30 + 30 = 60; livestock: 5 + 15 = 20
     country_rows = df[df.aoi_id == "BRA"]
-    cropland_country = country_rows[
-        country_rows.category == "cropland"
-    ].iloc[0]
+    cropland_country = country_rows[country_rows.category == "cropland"].iloc[0]
     assert cropland_country.gross_emissions_MgCO2e == 60.0
-    livestock_country = country_rows[
-        country_rows.category == "livestock"
-    ].iloc[0]
+    livestock_country = country_rows[country_rows.category == "livestock"].iloc[0]
     assert livestock_country.gross_emissions_MgCO2e == 20.0

--- a/pipelines/test/unit/land_ghg_inventory/test_agriculture_result_dataframe.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_agriculture_result_dataframe.py
@@ -5,8 +5,8 @@ from pipelines.prefect_flows import common_stages
 def test_agriculture_result_dataframe_rolls_up(synthetic_agriculture_datasets):
     datasets, expected_groups = synthetic_agriculture_datasets
 
-    cube, groupbys, out_expected_groups = agriculture_stages.setup_agriculture_compute(
-        datasets, expected_groups
+    cube, groupbys, out_expected_groups = (
+        agriculture_stages.setup_agriculture_compute(datasets, expected_groups)
     )
     reduced = common_stages.compute(cube, groupbys, out_expected_groups, "sum")
     df = agriculture_stages.agriculture_result_dataframe(reduced)
@@ -19,14 +19,28 @@ def test_agriculture_result_dataframe_rolls_up(synthetic_agriculture_datasets):
     }.issubset(df.columns)
     assert "land_state_class" not in df.columns
     assert "year" not in df.columns
-    assert set(df["category"]) == {"cropland"}
+    assert set(df["category"]) == {"cropland", "livestock"}
 
-    # subregion-level totals: top row pixels (10+20), one row per category
+    # subregion-level totals: top row pixels (10+20 cropland, 5+0 livestock),
+    # one row per category
     subregion_rows = df[df.aoi_id == "BRA.1.1"]
-    cropland_row = subregion_rows[subregion_rows.category == "cropland"].iloc[0]
+    cropland_row = subregion_rows[
+        subregion_rows.category == "cropland"
+    ].iloc[0]
     assert cropland_row.gross_emissions_MgCO2e == 30.0
+    livestock_row = subregion_rows[
+        subregion_rows.category == "livestock"
+    ].iloc[0]
+    assert livestock_row.gross_emissions_MgCO2e == 5.0
 
-    # country-level roll-up: subregion (30) + region-only bottom-left pixel (30)
+    # country-level roll-up: subregion + region-only bottom-left pixel
+    # cropland: 30 + 30 = 60; livestock: 5 + 15 = 20
     country_rows = df[df.aoi_id == "BRA"]
-    cropland_country = country_rows[country_rows.category == "cropland"].iloc[0]
+    cropland_country = country_rows[
+        country_rows.category == "cropland"
+    ].iloc[0]
     assert cropland_country.gross_emissions_MgCO2e == 60.0
+    livestock_country = country_rows[
+        country_rows.category == "livestock"
+    ].iloc[0]
+    assert livestock_country.gross_emissions_MgCO2e == 20.0

--- a/pipelines/test/unit/land_ghg_inventory/test_agriculture_setup_compute.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_agriculture_setup_compute.py
@@ -6,14 +6,16 @@ def test_setup_agriculture_compute_builds_measure_cube_and_groupbys(
 ):
     datasets, expected_groups = synthetic_agriculture_datasets
 
-    cube, groupbys, out_expected_groups = agriculture_stages.setup_agriculture_compute(
-        datasets, expected_groups
+    cube, groupbys, out_expected_groups = (
+        agriculture_stages.setup_agriculture_compute(datasets, expected_groups)
     )
 
-    assert list(cube.category.values) == ["cropland"]
+    assert list(cube.category.values) == ["cropland", "livestock"]
     # values pass through unchanged (already per-pixel absolute totals)
     cropland = cube.sel(category="cropland").values
     assert (cropland == [[10.0, 20.0], [30.0, 0.0]]).all()
+    livestock = cube.sel(category="livestock").values
+    assert (livestock == [[5.0, 0.0], [15.0, 0.0]]).all()
 
     assert [g.name for g in groupbys] == ["country", "region", "subregion"]
     assert out_expected_groups is expected_groups

--- a/pipelines/test/unit/land_ghg_inventory/test_agriculture_setup_compute.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_agriculture_setup_compute.py
@@ -6,8 +6,8 @@ def test_setup_agriculture_compute_builds_measure_cube_and_groupbys(
 ):
     datasets, expected_groups = synthetic_agriculture_datasets
 
-    cube, groupbys, out_expected_groups = (
-        agriculture_stages.setup_agriculture_compute(datasets, expected_groups)
+    cube, groupbys, out_expected_groups = agriculture_stages.setup_agriculture_compute(
+        datasets, expected_groups
     )
 
     assert list(cube.category.values) == ["cropland", "livestock"]

--- a/pipelines/test/unit/land_ghg_inventory/test_create_agriculture_zarr.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_create_agriculture_zarr.py
@@ -66,7 +66,7 @@ def test_create_agriculture_zarr_writes_expected_shape(
         patch.object(
             mod.rio,
             "open_rasterio",
-            side_effect=[_fake_cog(10_000.0)],
+            side_effect=[_fake_cog(10_000.0), _fake_cog(2_000.0)],
         ),
         patch.object(mod, "align_to", return_value=pixel_area_layer),
         patch.object(xr.Dataset, "to_zarr", fake_to_zarr),
@@ -79,8 +79,8 @@ def test_create_agriculture_zarr_writes_expected_shape(
     assert captured["mode"] == "w"
 
     ds = captured["ds"].compute()
-    # matches what agriculture_stages.load_agriculture expects: only this
-    # variable, dims (y, x) with no leftover band dim.
+    # matches what agriculture_stages.load_agriculture expects: cropland +
+    # livestock variables, dims (y, x) with no leftover band dim.
     assert set(ds.data_vars) == set(AGRICULTURE_SOURCE_VARS.values())
     assert ds.sizes.keys() == {"y", "x"}
     assert "band" not in ds.dims
@@ -89,9 +89,13 @@ def test_create_agriculture_zarr_writes_expected_shape(
     assert list(ds.y.values) == [1.0, 0.5, 0.0, -0.5]
     assert list(ds.x.values) == [0.0, 0.5, 1.0, 1.5]
 
-    # kg/ha -> ha-multiplied -> Mg conversion applied: 10_000 kg/ha * 5 ha / 1000
+    # kg/ha -> ha-multiplied -> Mg conversion applied:
+    # cropland: 10_000 kg/ha * 5 ha / 1000 = 50
+    # livestock: 2_000 kg/ha * 5 ha / 1000 = 10
     cropland = ds[AGRICULTURE_SOURCE_VARS["cropland"]].values
     assert cropland[0, 0] == pytest.approx(50.0)
+    livestock = ds[AGRICULTURE_SOURCE_VARS["livestock"]].values
+    assert livestock[0, 0] == pytest.approx(10.0)
 
 
 def test_create_agriculture_zarr_skips_when_present_and_not_overwrite():
@@ -117,7 +121,7 @@ def test_create_agriculture_zarr_overwrite_skips_exists_check(
         patch.object(
             mod.rio,
             "open_rasterio",
-            side_effect=[_fake_cog(1_000.0)],
+            side_effect=[_fake_cog(1_000.0), _fake_cog(500.0)],
         ),
         patch.object(mod, "align_to", return_value=pixel_area_layer),
         patch.object(xr.Dataset, "to_zarr"),

--- a/pipelines/test/unit/land_ghg_inventory/test_create_agriculture_zarr.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_create_agriculture_zarr.py
@@ -25,8 +25,20 @@ def reference_veg_dataset():
     return xr.Dataset({mod.REFERENCE_GRID_VAR: ref})
 
 
-def _fake_cog(value):
-    """A coarser source raster (kg/ha), band dim included like a real GeoTIFF read."""
+def _fake_cropland_cog(value):
+    """A coarser source raster (absolute kg total per pixel), matching the
+    reference grid 2:1 per axis so each source pixel has exactly 4 children."""
+    arr = xr.DataArray(
+        da.from_array(np.full((1, 2, 2), value, dtype="float32"), chunks=(1, 2, 2)),
+        dims=["band", "y", "x"],
+        coords={"band": [1], "y": [1.0, 0.0], "x": [0.0, 1.0]},
+    )
+    arr.rio.write_crs("EPSG:4326", inplace=True)
+    return arr
+
+
+def _fake_livestock_cog(value):
+    """A coarser source raster (kg/ha rate), band dim included like a real GeoTIFF read."""
     arr = xr.DataArray(
         da.from_array(np.full((1, 2, 2), value, dtype="float32"), chunks=(1, 2, 2)),
         dims=["band", "y", "x"],
@@ -67,7 +79,7 @@ def test_create_agriculture_zarr_writes_expected_shape(
         patch.object(
             mod.rio,
             "open_rasterio",
-            side_effect=[_fake_cog(10_000.0), _fake_cog(2_000.0)],
+            side_effect=[_fake_cropland_cog(400.0), _fake_livestock_cog(2_000.0)],
         ),
         patch.object(mod, "align_to", return_value=pixel_area_layer) as mock_align_to,
         patch.object(xr.Dataset, "to_zarr", fake_to_zarr),
@@ -79,8 +91,8 @@ def test_create_agriculture_zarr_writes_expected_shape(
     assert captured["group"] == "pipeline"
     assert captured["mode"] == "w"
 
-    # pixel area is aligned once and reused for both categories, since both
-    # source rasters are reprojected onto the same geobox.
+    # pixel area is only needed for livestock now (cropland uses the
+    # mass-conserving uniform-split path instead of an area multiply).
     mock_align_to.assert_called_once()
 
     ds = captured["ds"].compute()
@@ -94,11 +106,18 @@ def test_create_agriculture_zarr_writes_expected_shape(
     assert list(ds.y.values) == [1.0, 0.5, 0.0, -0.5]
     assert list(ds.x.values) == [0.0, 0.5, 1.0, 1.5]
 
-    # kg/ha -> ha-multiplied -> Mg conversion applied:
-    # cropland: 10_000 kg/ha * 5 ha / 1000 = 50
-    # livestock: 2_000 kg/ha * 5 ha / 1000 = 10
+    # cropland: absolute per-pixel total (400 kg), split across however many
+    # 30m reference pixels a nearest-neighbor reprojection maps each of the
+    # 4 source pixels onto (uneven here due to grid misalignment: child
+    # counts of 1, 2, 2, 4 for the 4 source pixels), then kg -> Mg. Summing
+    # over each source pixel's own children reproduces that source pixel's
+    # 400 kg / 1000 = 0.4 Mg; the grand total is 4 source pixels x 0.4 Mg.
     cropland = ds[AGRICULTURE_SOURCE_VARS["cropland"]].values
-    assert cropland[0, 0] == pytest.approx(50.0)
+    assert cropland[0, 0] == pytest.approx(400.0 / mod.KG_PER_MG)
+    assert np.nansum(cropland) == pytest.approx(4 * 400.0 / mod.KG_PER_MG)
+
+    # livestock: kg/ha -> ha-multiplied -> Mg conversion applied:
+    # 2_000 kg/ha * 5 ha / 1000 = 10
     livestock = ds[AGRICULTURE_SOURCE_VARS["livestock"]].values
     assert livestock[0, 0] == pytest.approx(10.0)
 
@@ -126,7 +145,7 @@ def test_create_agriculture_zarr_overwrite_skips_exists_check(
         patch.object(
             mod.rio,
             "open_rasterio",
-            side_effect=[_fake_cog(1_000.0), _fake_cog(500.0)],
+            side_effect=[_fake_cropland_cog(100.0), _fake_livestock_cog(500.0)],
         ),
         patch.object(mod, "align_to", return_value=pixel_area_layer),
         patch.object(xr.Dataset, "to_zarr"),
@@ -134,3 +153,41 @@ def test_create_agriculture_zarr_overwrite_skips_exists_check(
         mod.create_agriculture_zarr(overwrite=True)
 
     mock_exists.assert_not_called()
+
+
+def test_resample_total_uniformly_conserves_mass_per_source_pixel(reference_veg_dataset):
+    """Each source pixel keeps a distinct value, so that summing the
+    reprojected output over just the children of one source pixel (not the
+    whole grid) is a meaningful check -- verifies conservation isn't masked
+    by every source pixel happening to carry the same value. Grid
+    misalignment gives the source pixels uneven child counts (1, 2, 2, 4 out
+    of 16 destination pixels; the rest fall outside the source and are 0),
+    so an unweighted nearest-neighbor replication (no division) would
+    over-count the pixels with more children -- this checks each source
+    pixel's own total is reproduced regardless of its child count."""
+    distinct_cog = xr.DataArray(
+        da.from_array(
+            np.array([[100.0, 200.0], [300.0, 400.0]], dtype="float32").reshape(1, 2, 2),
+            chunks=(1, 2, 2),
+        ),
+        dims=["band", "y", "x"],
+        coords={"band": [1], "y": [1.0, 0.0], "x": [0.0, 1.0]},
+    )
+    distinct_cog.rio.write_crs("EPSG:4326", inplace=True)
+
+    with patch.object(mod.xr, "open_zarr", return_value=reference_veg_dataset):
+        geobox = mod._reference_geobox()
+
+    with patch.object(mod.rio, "open_rasterio", return_value=distinct_cog):
+        result = mod._resample_total_uniformly("fake_uri", geobox).compute()
+
+    # source pixel (0,0)=100 -> destination (0,0) only (1 child)
+    assert result.values[0, 0] == pytest.approx(100.0)
+    # source pixel (0,1)=200 -> destination (0,1),(0,2) (2 children)
+    assert np.nansum(result.values[0, 1:3]) == pytest.approx(200.0)
+    # source pixel (1,0)=300 -> destination (1,0),(2,0) (2 children)
+    assert np.nansum(result.values[1:3, 0]) == pytest.approx(300.0)
+    # source pixel (1,1)=400 -> destination (1,1),(1,2),(2,1),(2,2) (4 children)
+    assert np.nansum(result.values[1:3, 1:3]) == pytest.approx(400.0)
+    # row/col 3 (y=-0.5, x=1.5) fall outside the source raster entirely
+    assert np.all(result.values[3, :] == 0) or np.all(np.isnan(result.values[3, :]))

--- a/pipelines/test/unit/land_ghg_inventory/test_create_agriculture_zarr.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_create_agriculture_zarr.py
@@ -4,6 +4,7 @@ import dask.array as da
 import numpy as np
 import pytest
 import xarray as xr
+
 from pipelines.globals import land_ghg_inventory_agriculture_zarr_uri
 from pipelines.land_ghg_inventory import create_agriculture_zarr as mod
 from pipelines.land_ghg_inventory.agriculture_stages import AGRICULTURE_SOURCE_VARS
@@ -68,7 +69,7 @@ def test_create_agriculture_zarr_writes_expected_shape(
             "open_rasterio",
             side_effect=[_fake_cog(10_000.0), _fake_cog(2_000.0)],
         ),
-        patch.object(mod, "align_to", return_value=pixel_area_layer),
+        patch.object(mod, "align_to", return_value=pixel_area_layer) as mock_align_to,
         patch.object(xr.Dataset, "to_zarr", fake_to_zarr),
     ):
         result_uri = mod.create_agriculture_zarr(overwrite=False)
@@ -77,6 +78,10 @@ def test_create_agriculture_zarr_writes_expected_shape(
     assert captured["uri"] == land_ghg_inventory_agriculture_zarr_uri
     assert captured["group"] == "pipeline"
     assert captured["mode"] == "w"
+
+    # pixel area is aligned once and reused for both categories, since both
+    # source rasters are reprojected onto the same geobox.
+    mock_align_to.assert_called_once()
 
     ds = captured["ds"].compute()
     # matches what agriculture_stages.load_agriculture expects: cropland +

--- a/pipelines/test/unit/land_ghg_inventory/test_create_agriculture_zarr.py
+++ b/pipelines/test/unit/land_ghg_inventory/test_create_agriculture_zarr.py
@@ -27,11 +27,15 @@ def reference_veg_dataset():
 
 def _fake_cropland_cog(value):
     """A coarser source raster (absolute kg total per pixel), matching the
-    reference grid 2:1 per axis so each source pixel has exactly 4 children."""
+    reference grid 2:1 per axis so each source pixel has exactly 4 children.
+    Pixel centers are offset (0.75/-0.25, 0.25/1.25) rather than aligned with
+    the reference grid's origin, so its bounds (-0.5..1.5) fully cover the
+    reference grid's bounds (-0.25..1.75, -0.75..1.25) -- ``_resample_total_uniformly``
+    assumes full coverage, as the real global-to-global grids have."""
     arr = xr.DataArray(
         da.from_array(np.full((1, 2, 2), value, dtype="float32"), chunks=(1, 2, 2)),
         dims=["band", "y", "x"],
-        coords={"band": [1], "y": [1.0, 0.0], "x": [0.0, 1.0]},
+        coords={"band": [1], "y": [0.75, -0.25], "x": [0.25, 1.25]},
     )
     arr.rio.write_crs("EPSG:4326", inplace=True)
     return arr
@@ -106,14 +110,13 @@ def test_create_agriculture_zarr_writes_expected_shape(
     assert list(ds.y.values) == [1.0, 0.5, 0.0, -0.5]
     assert list(ds.x.values) == [0.0, 0.5, 1.0, 1.5]
 
-    # cropland: absolute per-pixel total (400 kg), split across however many
-    # 30m reference pixels a nearest-neighbor reprojection maps each of the
-    # 4 source pixels onto (uneven here due to grid misalignment: child
-    # counts of 1, 2, 2, 4 for the 4 source pixels), then kg -> Mg. Summing
-    # over each source pixel's own children reproduces that source pixel's
-    # 400 kg / 1000 = 0.4 Mg; the grand total is 4 source pixels x 0.4 Mg.
+    # cropland: absolute per-pixel total (400 kg), divided by the (here,
+    # exact: 1.0/0.5 = 2 per axis) child count per source pixel -- 4 children
+    # each get 400/4=100 kg, then kg -> Mg: 0.1. Each 2x2 block of the 4x4
+    # destination grid corresponds to one of the 4 (identical-valued) source
+    # pixels, so the grand total is 4 source pixels x 0.4 Mg.
     cropland = ds[AGRICULTURE_SOURCE_VARS["cropland"]].values
-    assert cropland[0, 0] == pytest.approx(400.0 / mod.KG_PER_MG)
+    assert cropland[0, 0] == pytest.approx(400.0 / 4 / mod.KG_PER_MG)
     assert np.nansum(cropland) == pytest.approx(4 * 400.0 / mod.KG_PER_MG)
 
     # livestock: kg/ha -> ha-multiplied -> Mg conversion applied:
@@ -155,23 +158,27 @@ def test_create_agriculture_zarr_overwrite_skips_exists_check(
     mock_exists.assert_not_called()
 
 
-def test_resample_total_uniformly_conserves_mass_per_source_pixel(reference_veg_dataset):
+def test_resample_total_uniformly_conserves_mass_per_source_pixel(
+    reference_veg_dataset,
+):
     """Each source pixel keeps a distinct value, so that summing the
     reprojected output over just the children of one source pixel (not the
     whole grid) is a meaningful check -- verifies conservation isn't masked
-    by every source pixel happening to carry the same value. Grid
-    misalignment gives the source pixels uneven child counts (1, 2, 2, 4 out
-    of 16 destination pixels; the rest fall outside the source and are 0),
-    so an unweighted nearest-neighbor replication (no division) would
-    over-count the pixels with more children -- this checks each source
-    pixel's own total is reproduced regardless of its child count."""
+    by every source pixel happening to carry the same value. This fixture's
+    resolution ratio (1.0 source / 0.5 destination = 2 per axis, 4 children
+    per source pixel) is an exact integer, so conservation holds exactly per
+    source pixel here (the real cropland grids' ratio isn't a whole number,
+    so real per-pixel conservation is only approximate -- see the module
+    docstring)."""
     distinct_cog = xr.DataArray(
         da.from_array(
-            np.array([[100.0, 200.0], [300.0, 400.0]], dtype="float32").reshape(1, 2, 2),
+            np.array([[100.0, 200.0], [300.0, 400.0]], dtype="float32").reshape(
+                1, 2, 2
+            ),
             chunks=(1, 2, 2),
         ),
         dims=["band", "y", "x"],
-        coords={"band": [1], "y": [1.0, 0.0], "x": [0.0, 1.0]},
+        coords={"band": [1], "y": [0.75, -0.25], "x": [0.25, 1.25]},
     )
     distinct_cog.rio.write_crs("EPSG:4326", inplace=True)
 
@@ -181,13 +188,13 @@ def test_resample_total_uniformly_conserves_mass_per_source_pixel(reference_veg_
     with patch.object(mod.rio, "open_rasterio", return_value=distinct_cog):
         result = mod._resample_total_uniformly("fake_uri", geobox).compute()
 
-    # source pixel (0,0)=100 -> destination (0,0) only (1 child)
-    assert result.values[0, 0] == pytest.approx(100.0)
-    # source pixel (0,1)=200 -> destination (0,1),(0,2) (2 children)
-    assert np.nansum(result.values[0, 1:3]) == pytest.approx(200.0)
-    # source pixel (1,0)=300 -> destination (1,0),(2,0) (2 children)
-    assert np.nansum(result.values[1:3, 0]) == pytest.approx(300.0)
-    # source pixel (1,1)=400 -> destination (1,1),(1,2),(2,1),(2,2) (4 children)
-    assert np.nansum(result.values[1:3, 1:3]) == pytest.approx(400.0)
-    # row/col 3 (y=-0.5, x=1.5) fall outside the source raster entirely
-    assert np.all(result.values[3, :] == 0) or np.all(np.isnan(result.values[3, :]))
+    # source pixel (0,0)=100 (covers y=[1.25,0.25], x=[-0.25,0.75]) ->
+    # destination (0,0),(0,1),(1,0),(1,1) (4 children)
+    assert np.nansum(result.values[0:2, 0:2]) == pytest.approx(100.0)
+    # source pixel (0,1)=200 -> destination (0,2),(0,3),(1,2),(1,3)
+    assert np.nansum(result.values[0:2, 2:4]) == pytest.approx(200.0)
+    # source pixel (1,0)=300 -> destination (2,0),(2,1),(3,0),(3,1)
+    assert np.nansum(result.values[2:4, 0:2]) == pytest.approx(300.0)
+    # source pixel (1,1)=400 -> destination (2,2),(2,3),(3,2),(3,3)
+    assert np.nansum(result.values[2:4, 2:4]) == pytest.approx(400.0)
+    assert np.nansum(result.values) == pytest.approx(100.0 + 200.0 + 300.0 + 400.0)


### PR DESCRIPTION
# Add livestock emissions to the agriculture component (pipeline + API)

## Summary

Adds `livestock` as a second category alongside `cropland` in the `land_ghg_inventory` `agriculture` component. `agriculture` already models emissions as rows discriminated by a generic `category` column, so livestock is a new category value throughout the existing pipeline and API code path — no new component, Prefect flow, router, or terraform change needed.

## Source raster

```
s3://gfw2-data/climate/AFOLU_flux_model/livestock_emissions/raw__from_Cornell/
20260731_emis_per_ha_only/Total_GHG_Emissions/
Tot_CO2eq_kg_livestock_GHG_emissions_kgCO2e_ha.tif
```

Static single-year snapshot, per-hectare CO2-equivalent rate (`kgCO2e/ha`) — same shape and units as the cropland source COG, reusing the identical resample -> pixel-area-multiply -> kg-to-Mg conversion chain.

## Updated parquet output

`s3://lcl-analytics/zonal-statistics/land_ghg_inventory-agriculture/{version}/admin-land_ghg_inventory-agriculture.parquet`

Same schema as before, now with `category` taking two values instead of one:

| column | type | notes |
|---|---|---|
| `aoi_id` | str | e.g. `"BRA"`, `"BRA.1"`, `"BRA.1.1"` |
| `aoi_type` | str | always `"admin"` |
| `category` | str | `"cropland"` \| `"livestock"` |
| `gross_emissions_MgCO2e` | float | summed emissions for `aoi_id` x `category` |

## Updated API payload

`agriculture` gains a `livestock` category, and — like `mineral_soil` — its single static snapshot is now exploded into one row per vegetation year (2016-2024), each row repeating the same value, so all components share one consistent per-year shape:

```json
{
  "data": {
    "result": {
      "agriculture": {
        "aoi_id": ["BRA.1", "BRA.1", "BRA.1", "BRA.1"],
        "aoi_type": ["admin", "admin", "admin", "admin"],
        "category": ["cropland", "cropland", "livestock", "livestock"],
        "year": [2016, 2017, 2016, 2017],
        "gross_emissions_MgCO2e": [
          123234500000.0,
          123234500000.0,
          45123400000.0,
          45123400000.0
        ]
      }
    },
    "metadata": { "aoi": { "type": "admin", "ids": ["BRA.1"] } },
    "message": "Analysis completed successfully.",
    "status": "saved"
  },
  "status": "success"
}
```

## Changes

- `create_agriculture_zarr.py`: added `LIVESTOCK_COG_URI`; resamples both cropland and livestock COGs onto the shared reference geobox, converts each to absolute per-pixel `MgCO2e`, and writes both as separate variables into the agriculture zarr. Pixel area is aligned once and reused for both conversions.
- `agriculture_stages.py`: added `"livestock": "livestock_emissions"` to `AGRICULTURE_SOURCE_VARS` — the load/setup-compute/result-dataframe stages already iterate this dict generically.
- `land_ghg_inventory_analyzer.py`: bumped `admin_agriculture_results_uri` to the new parquet version. `analyze_agriculture` now explodes each `aoi_id x category` row into one row per vegetation year (2016-2024), matching `analyze_mineral_soil`'s existing exploded-year shape — agriculture is the same shape (single static snapshot, no year axis) and had been missed when that treatment was added for the soil components.
- `land_ghg_inventory.py` model: bumped `LandGHGInventoryAnalyticsIn._version` (`v20260731` -> `v20260803`) so cached responses from before this change aren't served stale; OpenAPI example updated to show both categories in the exploded-year shape.
- Tests: pipeline and API unit/integration tests extended to cover both categories and the exploded years.


FYI @jterry64: added this to the PR after approval -  may not be final version but this is best we can do for now

## Cropland resampling fix

QC against an independent country-level reference table (Cornell-sourced cropland GHG emissions by country) surfaced a ~5.3x global overstatement in cropland totals, unrelated to livestock. Root cause and fix:

- **Root cause**: the cropland source COG (`mean_rate_physical_area`, kg/ha) is a rate normalized to the *physical cropland area within each pixel* (e.g. SPAM2020; https://www.nature.com/articles/s41558-026-02558-4.pdf), not the pixel's full geographic area. The pipeline was multiplying this rate by the UMD pixel-area zarr (full pixel area), overstating absolute totals everywhere a pixel isn't 100% cropland — confirmed by reconstructing each pixel's implied normalization area (`total / rate`) and finding it's typically ~6% of the full pixel area, not 100%.
- **Fix**: switched `CROPLAND_COG_URI` to Cornell's `total_amount` COG (already an absolute per-pixel total in kg, no area normalization needed) and resample it by dividing each source pixel's total by its (unrounded) resolution-ratio-implied child count before an ordinary nearest-neighbor reprojection to the 30m grid — approximately splitting rather than replicating each parent pixel's total. Livestock's resample chain (rate × full pixel area) is unchanged, since its source COG is genuinely a full-pixel-area rate.
- **QC after the fix**: global cropland total within 0.44% of the reference (was ~425% over). Median relative difference across 186 matched countries: 0.84%; 75th percentile 2.3%; 90th percentile 10.5%. Top 20 emitters (85.7% of global reference total) median 0.4%. Remaining outliers are small/border-heavy territories with near-zero absolute totals, not large emitters.
- Updated `test_agriculture_flow.py`'s expected São Tomé & Príncipe cropland total accordingly (livestock's expected value is unchanged).

